### PR TITLE
Bugs and new features

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,7 @@ check_PROGRAMS = test_ics1 \
                  test_gzip \
                  test_strides \
                  test_strides2 \
+                 test_strides3 \
                  test_metadata \
                  test_history
 
@@ -57,6 +58,7 @@ test_compress_SOURCES = test_compress.c
 test_gzip_SOURCES = test_gzip.c
 test_strides_SOURCES = test_strides.c
 test_strides2_SOURCES = test_strides2.c
+test_strides3_SOURCES = test_strides3.c
 test_metadata_SOURCES = test_metadata.c
 test_history_SOURCES = test_history.c
 
@@ -67,6 +69,7 @@ test_compress_LDADD = libics.la
 test_gzip_LDADD = libics.la
 test_strides_LDADD = libics.la
 test_strides2_LDADD = libics.la
+test_strides3_LDADD = libics.la
 test_metadata_LDADD = libics.la
 test_history_LDADD = libics.la
 
@@ -77,6 +80,7 @@ TESTS = test_ics1.sh \
         test_gzip.sh \
         test_strides.sh \
         test_strides2.sh \
+        test_strides3.sh \
         test_metadata.sh \
         test_history.sh
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -103,7 +103,7 @@ build_triplet = @build@
 host_triplet = @host@
 check_PROGRAMS = test_ics1$(EXEEXT) test_ics2a$(EXEEXT) \
 	test_ics2b$(EXEEXT) test_compress$(EXEEXT) test_gzip$(EXEEXT) \
-	test_strides$(EXEEXT) test_strides2$(EXEEXT) \
+	test_strides$(EXEEXT) test_strides2$(EXEEXT) test_strides3$(EXEEXT) \
 	test_metadata$(EXEEXT) test_history$(EXEEXT)
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -159,7 +159,7 @@ libics_la_OBJECTS = $(am_libics_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
-am__v_lt_1 = 
+am__v_lt_1 =
 libics_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
 	$(libics_la_LDFLAGS) $(LDFLAGS) -o $@
@@ -190,6 +190,9 @@ test_strides_DEPENDENCIES = libics.la
 am_test_strides2_OBJECTS = test_strides2.$(OBJEXT)
 test_strides2_OBJECTS = $(am_test_strides2_OBJECTS)
 test_strides2_DEPENDENCIES = libics.la
+am_test_strides3_OBJECTS = test_strides3.$(OBJEXT)
+test_strides3_OBJECTS = $(am_test_strides3_OBJECTS)
+test_strides3_DEPENDENCIES = libics.la
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -197,11 +200,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__depfiles_maybe = depfiles
@@ -215,7 +218,7 @@ LTCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 AM_V_CC = $(am__v_CC_@AM_V@)
 am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
 am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 = 
+am__v_CC_1 =
 CCLD = $(CC)
 LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
@@ -223,17 +226,17 @@ LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 = 
+am__v_CCLD_1 =
 SOURCES = $(libics_la_SOURCES) $(test_compress_SOURCES) \
 	$(test_gzip_SOURCES) $(test_history_SOURCES) \
 	$(test_ics1_SOURCES) $(test_ics2a_SOURCES) \
 	$(test_ics2b_SOURCES) $(test_metadata_SOURCES) \
-	$(test_strides_SOURCES) $(test_strides2_SOURCES)
+	$(test_strides_SOURCES) $(test_strides2_SOURCES) $(test_strides3_SOURCES)
 DIST_SOURCES = $(libics_la_SOURCES) $(test_compress_SOURCES) \
 	$(test_gzip_SOURCES) $(test_history_SOURCES) \
 	$(test_ics1_SOURCES) $(test_ics2a_SOURCES) \
 	$(test_ics2b_SOURCES) $(test_metadata_SOURCES) \
-	$(test_strides_SOURCES) $(test_strides2_SOURCES)
+	$(test_strides_SOURCES) $(test_strides2_SOURCES) $(test_strides3_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -613,6 +616,7 @@ test_compress_SOURCES = test_compress.c
 test_gzip_SOURCES = test_gzip.c
 test_strides_SOURCES = test_strides.c
 test_strides2_SOURCES = test_strides2.c
+test_strides3_SOURCES = test_strides3.c
 test_metadata_SOURCES = test_metadata.c
 test_history_SOURCES = test_history.c
 test_ics1_LDADD = libics.la
@@ -622,6 +626,7 @@ test_compress_LDADD = libics.la
 test_gzip_LDADD = libics.la
 test_strides_LDADD = libics.la
 test_strides2_LDADD = libics.la
+test_strides3_LDADD = libics.la
 test_metadata_LDADD = libics.la
 test_history_LDADD = libics.la
 TESTS = test_ics1.sh \
@@ -631,6 +636,7 @@ TESTS = test_ics1.sh \
         test_gzip.sh \
         test_strides.sh \
         test_strides2.sh \
+        test_strides3.sh \
         test_metadata.sh \
         test_history.sh
 
@@ -721,7 +727,7 @@ config.h: stamp-h1
 stamp-h1: $(srcdir)/config.h.in $(top_builddir)/config.status
 	@rm -f stamp-h1
 	cd $(top_builddir) && $(SHELL) ./config.status config.h
-$(srcdir)/config.h.in: @MAINTAINER_MODE_TRUE@ $(am__configure_deps) 
+$(srcdir)/config.h.in: @MAINTAINER_MODE_TRUE@ $(am__configure_deps)
 	($(am__cd) $(top_srcdir) && $(AUTOHEADER))
 	rm -f stamp-h1
 	touch $@
@@ -772,7 +778,7 @@ clean-libLTLIBRARIES:
 	  rm -f $${locs}; \
 	}
 
-libics.la: $(libics_la_OBJECTS) $(libics_la_DEPENDENCIES) $(EXTRA_libics_la_DEPENDENCIES) 
+libics.la: $(libics_la_OBJECTS) $(libics_la_DEPENDENCIES) $(EXTRA_libics_la_DEPENDENCIES)
 	$(AM_V_CCLD)$(libics_la_LINK) -rpath $(libdir) $(libics_la_OBJECTS) $(libics_la_LIBADD) $(LIBS)
 
 clean-checkPROGRAMS:
@@ -784,41 +790,45 @@ clean-checkPROGRAMS:
 	echo " rm -f" $$list; \
 	rm -f $$list
 
-test_compress$(EXEEXT): $(test_compress_OBJECTS) $(test_compress_DEPENDENCIES) $(EXTRA_test_compress_DEPENDENCIES) 
+test_compress$(EXEEXT): $(test_compress_OBJECTS) $(test_compress_DEPENDENCIES) $(EXTRA_test_compress_DEPENDENCIES)
 	@rm -f test_compress$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_compress_OBJECTS) $(test_compress_LDADD) $(LIBS)
 
-test_gzip$(EXEEXT): $(test_gzip_OBJECTS) $(test_gzip_DEPENDENCIES) $(EXTRA_test_gzip_DEPENDENCIES) 
+test_gzip$(EXEEXT): $(test_gzip_OBJECTS) $(test_gzip_DEPENDENCIES) $(EXTRA_test_gzip_DEPENDENCIES)
 	@rm -f test_gzip$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_gzip_OBJECTS) $(test_gzip_LDADD) $(LIBS)
 
-test_history$(EXEEXT): $(test_history_OBJECTS) $(test_history_DEPENDENCIES) $(EXTRA_test_history_DEPENDENCIES) 
+test_history$(EXEEXT): $(test_history_OBJECTS) $(test_history_DEPENDENCIES) $(EXTRA_test_history_DEPENDENCIES)
 	@rm -f test_history$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_history_OBJECTS) $(test_history_LDADD) $(LIBS)
 
-test_ics1$(EXEEXT): $(test_ics1_OBJECTS) $(test_ics1_DEPENDENCIES) $(EXTRA_test_ics1_DEPENDENCIES) 
+test_ics1$(EXEEXT): $(test_ics1_OBJECTS) $(test_ics1_DEPENDENCIES) $(EXTRA_test_ics1_DEPENDENCIES)
 	@rm -f test_ics1$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_ics1_OBJECTS) $(test_ics1_LDADD) $(LIBS)
 
-test_ics2a$(EXEEXT): $(test_ics2a_OBJECTS) $(test_ics2a_DEPENDENCIES) $(EXTRA_test_ics2a_DEPENDENCIES) 
+test_ics2a$(EXEEXT): $(test_ics2a_OBJECTS) $(test_ics2a_DEPENDENCIES) $(EXTRA_test_ics2a_DEPENDENCIES)
 	@rm -f test_ics2a$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_ics2a_OBJECTS) $(test_ics2a_LDADD) $(LIBS)
 
-test_ics2b$(EXEEXT): $(test_ics2b_OBJECTS) $(test_ics2b_DEPENDENCIES) $(EXTRA_test_ics2b_DEPENDENCIES) 
+test_ics2b$(EXEEXT): $(test_ics2b_OBJECTS) $(test_ics2b_DEPENDENCIES) $(EXTRA_test_ics2b_DEPENDENCIES)
 	@rm -f test_ics2b$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_ics2b_OBJECTS) $(test_ics2b_LDADD) $(LIBS)
 
-test_metadata$(EXEEXT): $(test_metadata_OBJECTS) $(test_metadata_DEPENDENCIES) $(EXTRA_test_metadata_DEPENDENCIES) 
+test_metadata$(EXEEXT): $(test_metadata_OBJECTS) $(test_metadata_DEPENDENCIES) $(EXTRA_test_metadata_DEPENDENCIES)
 	@rm -f test_metadata$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_metadata_OBJECTS) $(test_metadata_LDADD) $(LIBS)
 
-test_strides$(EXEEXT): $(test_strides_OBJECTS) $(test_strides_DEPENDENCIES) $(EXTRA_test_strides_DEPENDENCIES) 
+test_strides$(EXEEXT): $(test_strides_OBJECTS) $(test_strides_DEPENDENCIES) $(EXTRA_test_strides_DEPENDENCIES)
 	@rm -f test_strides$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_strides_OBJECTS) $(test_strides_LDADD) $(LIBS)
 
-test_strides2$(EXEEXT): $(test_strides2_OBJECTS) $(test_strides2_DEPENDENCIES) $(EXTRA_test_strides2_DEPENDENCIES) 
+test_strides2$(EXEEXT): $(test_strides2_OBJECTS) $(test_strides2_DEPENDENCIES) $(EXTRA_test_strides2_DEPENDENCIES)
 	@rm -f test_strides2$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(test_strides2_OBJECTS) $(test_strides2_LDADD) $(LIBS)
+
+test_strides3$(EXEEXT): $(test_strides3_OBJECTS) $(test_strides3_DEPENDENCIES) $(EXTRA_test_strides3_DEPENDENCIES)
+	@rm -f test_strides3$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(test_strides3_OBJECTS) $(test_strides3_LDADD) $(LIBS)
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
@@ -847,6 +857,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_metadata.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_strides.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_strides2.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_strides3.Po@am__quote@
 
 .c.o:
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(COMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
@@ -1144,6 +1155,13 @@ test_strides.sh.log: test_strides.sh
 test_strides2.sh.log: test_strides2.sh
 	@p='test_strides2.sh'; \
 	b='test_strides2.sh'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_strides3.sh.log: test_strides3.sh
+	@p='test_strides3.sh'; \
+	b='test_strides3.sh'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \

--- a/docs/Ics_Error.html
+++ b/docs/Ics_Error.html
@@ -70,7 +70,7 @@
     <p>Some error occurred during compression.</p>
 
   <h3 class="ident">IcsErr_CorruptedStream</h3>
-    <p>The compressed input stream is currupted.</p>
+    <p>The compressed input stream is corrupted.</p>
 
   <h3 class="ident">IcsErr_DecompressionProblem</h3>
     <p>Some error occurred during decompression.</p>
@@ -113,7 +113,7 @@
     <p>File read error on data file.</p>
 
   <h3 class="ident">IcsErr_FTempMoveIcs</h3>
-    <p>Failed to remane .ics file opened for updating.</p>
+    <p>Failed to rename .ics file opened for updating.</p>
 
   <h3 class="ident">IcsErr_FWriteIcs</h3>
     <p>File write error on .ics file.</p>
@@ -189,7 +189,7 @@
     <p>Unknown compression type.</p>
 
   <h3 class="ident">IcsErr_UnknownDataType</h3>
-    <p>The datatype is not recognized.</p>
+    <p>The data type is not recognized.</p>
 
   <h3 class="ident">IcsErr_WrongZlibVersion</h3>
     <p>libics is linking to a different version of zlib

--- a/docs/Ics_Header.html
+++ b/docs/Ics_Header.html
@@ -152,7 +152,7 @@
     neighbors. Not used when reading.</p>
 
     <p class="info"><span class="headtxt">type</span>:
-    <tt class="keyword">size_t const*</tt></p>
+    <tt class="keyword">ptrdiff_t const*</tt></p>
 
     <p class="info"><span class="headtxt">access</span>:
     <tt class="funcident"><a href="TopLevelFunctions.html#IcsSetDataWithStrides">IcsSetDataWithStrides</a></tt>.</p>

--- a/docs/TopLevelFunctions.html
+++ b/docs/TopLevelFunctions.html
@@ -338,7 +338,7 @@
     (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
     <span class="keyword">void&nbsp;const</span>*&nbsp;<span class="varident">src</span>,
     <span class="keyword">size_t</span>&nbsp;<span class="varident">n</span>,
-    <span class="keyword">size_t&nbsp;const</span>*&nbsp;<span class="varident">strides</span>,
+    <span class="keyword">ptrdiff_t&nbsp;const</span>*&nbsp;<span class="varident">strides</span>,
     <span class="keyword">int</span>&nbsp;<span class="varident">ndims</span>);
     </p>
 
@@ -351,6 +351,8 @@
 
     <p>This function does currently not work when the data is compressed with
     <tt class="constant"><a href="Enums.html#Ics_Compression">IcsCompr_compress</a></tt>.</p>
+
+    <p>The parameter <tt class="varident">n</tt> is ignored.</p>
 
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_Alloc</tt>,
@@ -582,7 +584,7 @@
     (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
     <span class="keyword">void&nbsp;const</span>*&nbsp;<span class="varident">src</span>,
     <span class="keyword">size_t</span>&nbsp;<span class="varident">n</span>,
-    <span class="keyword">size_t&nbsp;const</span>*&nbsp;<span class="varident">strides</span>,
+    <span class="keyword">ptrdiff_t&nbsp;const</span>*&nbsp;<span class="varident">strides</span>,
     <span class="keyword">int</span>&nbsp;<span class="varident">ndims</span>);
     </p>
 
@@ -594,6 +596,8 @@
     <tt class="varident">ndims</tt> is the length of this array and should be
     equal to the dimensionality of the data as specified earlier through
     <tt class="funcident"><a href="#IcsSetLayout">IcsSetLayout</a></tt></p>
+
+    <p>The parameter <tt class="varident">n</tt> is ignored.</p>
 
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_DuplicateData</tt>,

--- a/docs/TopLevelFunctions.html
+++ b/docs/TopLevelFunctions.html
@@ -683,6 +683,24 @@
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_NotValidAction</tt>.</p>
 
+  <h3 class="ident"><a name="IcsGetImelUnitsF"></a>IcsGetImelUnitsF</h3>
+
+    <p class="synopsis">
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetImelUnitsF</span>
+    (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>&nbsp<span class="keyword">const</span>*&nbsp;<span class="varident">ics</span>,
+    <span class="keyword">double</span>*&nbsp;<span class="varident">origin</span>,
+    <span class="keyword">double</span>*&nbsp;<span class="varident">scale</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">units</span>);
+    </p>
+
+    <p>Same as <tt class="funcident"><a href="#IcsGetImelUnits">IcsGetImelUnits</a></tt>,
+    but doesn't copy the units string. Output pointer <tt class="varident">units</tt>
+    is set to the internal buffer, which will be valid until
+    <tt class="funcident"><a href="#IcsClose">IcsClose</a></tt> is called.</p>
+
+    <p class="info"><span class="headtxt">errors</span>:
+    <tt class="constant">IcsErr_NotValidAction</tt>.</p>
+
   <h3 class="ident"><a name="IcsGetOrder"></a>IcsGetOrder</h3>
 
     <p class="synopsis">
@@ -696,6 +714,24 @@
     <p>Get the ordering of the dimensions in the image. The
     ordering is defined by names and labels for each dimension. The defaults
     are x, y, z, t (time) and p (probe). Dimensions start at 0.</p>
+
+    <p class="info"><span class="headtxt">errors</span>:
+    <tt class="constant">IcsErr_NotValidAction</tt>.</p>
+
+  <h3 class="ident"><a name="IcsGetOrderF"></a>IcsGetOrderF</h3>
+
+    <p class="synopsis">
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetOrderF</span>
+    (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>&nbsp<span class="keyword">const</span>*&nbsp;<span class="varident">ics</span>,
+    <span class="keyword">int</span>&nbsp;<span class="varident">dimension</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">order</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">label</span>);
+    </p>
+
+    <p>Same as <tt class="funcident"><a href="#IcsGetOrder">IcsGetOrder</a></tt>,
+    but doesn't copy the order or label strings. Output pointers <tt class="varident">order</tt>
+    and <tt class="varident">label</tt> are set to the internal buffers, which will
+    be valid until <tt class="funcident"><a href="#IcsClose">IcsClose</a></tt> is called.</p>
 
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_NotValidAction</tt>.</p>
@@ -715,6 +751,25 @@
     origin of the first pixel, the distances between pixels and the units in
     which to measure. If you are not interested in one of the parameters, set
     the pointer to <tt class="constant">NULL</tt>. Dimensions start at 0.</p>
+
+    <p class="info"><span class="headtxt">errors</span>:
+    <tt class="constant">IcsErr_NotValidAction</tt>.</p>
+
+  <h3 class="ident"><a name="IcsGetPositionF"></a>IcsGetPositionF</h3>
+
+    <p class="synopsis">
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetPositionF</span>
+    (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>&nbsp<span class="keyword">const</span>*&nbsp;<span class="varident">ics</span>,
+    <span class="keyword">int</span>&nbsp;<span class="varident">dimension</span>,
+    <span class="keyword">double</span>*&nbsp;<span class="varident">origin</span>,
+    <span class="keyword">double</span>*&nbsp;<span class="varident">scale</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">units</span>);
+    </p>
+
+    <p>Same as <tt class="funcident"><a href="#IcsGetPosition">IcsGetPosition</a></tt>,
+    but doesn't copy the units string. Output pointer <tt class="varident">units</tt>
+    is set to the internal buffer, which will be valid until
+    <tt class="funcident"><a href="#IcsClose">IcsClose</a></tt> is called.</p>
 
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_NotValidAction</tt>.</p>
@@ -964,6 +1019,27 @@
     <tt class="constant">IcsErr_EndOfHistory</tt>,
     <tt class="constant">IcsErr_NotValidAction</tt>.</p>
 
+  <h3 class="ident"><a name="IcsGetHistoryKeyValueIF"></a>IcsGetHistoryKeyValueIF</h3>
+
+    <p class="synopsis">
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetHistoryKeyValueIF</span>
+    (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
+    <span class="typeident">Ics_HistoryIterator</span>*&nbsp;<span class="varident">it</span>,
+    <span class="keyword">char</span>*&nbsp;<span class="varident">key</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">value</span>);
+    </p>
+
+    <p>Same as <tt class="funcident"><a href="#IcsGetHistoryKeyValueI">IcsGetHistoryKeyValueI</a></tt>,
+    but doesn't copy the value string. Output pointer <tt class="varident">value</tt>
+    is set to the internal buffer, which will be valid until
+    <tt class="funcident"><a href="#IcsClose">IcsClose</a></tt> or
+    <tt class="funcident"><a href="#IcsFreeHistory">IcsFreeHistory</a></tt>
+    are called.</p>
+
+    <p class="info"><span class="headtxt">errors</span>:
+    <tt class="constant">IcsErr_EndOfHistory</tt>,
+    <tt class="constant">IcsErr_NotValidAction</tt>.</p>
+
   <h3 class="ident"><a name="IcsGetHistoryString"></a>IcsGetHistoryString</h3>
 
     <p class="synopsis">
@@ -1003,6 +1079,26 @@
     The <tt class="varident">it</tt> parameter must point to a
     <tt class="typeident">Ics_HistoryIterator</tt> structure initialized by
     <tt class="funcident"><a href="#IcsNewHistoryIterator">IcsNewHistoryIterator</a></tt>.</p>
+
+    <p class="info"><span class="headtxt">errors</span>:
+    <tt class="constant">IcsErr_EndOfHistory</tt>,
+    <tt class="constant">IcsErr_NotValidAction</tt>.</p>
+
+  <h3 class="ident"><a name="IcsGetHistoryStringIF"></a>IcsGetHistoryStringIF</h3>
+
+    <p class="synopsis">
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetHistoryStringIF</span>
+    (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
+    <span class="typeident">Ics_HistoryIterator</span>*&nbsp;<span class="varident">it</span>,
+    <span class="keyword">const char</span>**&nbsp;<span class="varident">string</span>);
+    </p>
+
+    <p>Same as <tt class="funcident"><a href="#IcsGetHistoryKeyValueI">IcsGetHistoryKeyValueI</a></tt>,
+    but doesn't copy the string. Output pointer <tt class="varident">string</tt>
+    is set to the internal buffer, which will be valid until
+    <tt class="funcident"><a href="#IcsClose">IcsClose</a></tt> or
+    <tt class="funcident"><a href="#IcsFreeHistory">IcsFreeHistory</a></tt>
+    are called.</p>
 
     <p class="info"><span class="headtxt">errors</span>:
     <tt class="constant">IcsErr_EndOfHistory</tt>,

--- a/docs/TopLevelFunctions.html
+++ b/docs/TopLevelFunctions.html
@@ -887,7 +887,7 @@
   <h3 class="ident"><a name="IcsDeleteHistory"></a>IcsDeleteHistory</h3>
 
     <p class="synopsis">
-    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetHistory</span>
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsDeleteHistory</span>
     (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
     <span class="keyword">char</span>*&nbsp;<span class="varident">key</span>);
     </p>
@@ -902,7 +902,7 @@
   <h3 class="ident"><a name="IcsDeleteHistoryStringI"></a>IcsDeleteHistoryStringI</h3>
 
     <p class="synopsis">
-    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsGetHistoryStringI</span>
+    <span class="typeident"><a href="Ics_Error.html">Ics_Error</a></span>&nbsp;<span class="funcident">IcsDeleteHistoryStringI</span>
     (<span class="typeident"><a href="Ics_Header.html">ICS</a></span>*&nbsp;<span class="varident">ics</span>,
     <span class="typeident">Ics_HistoryIterator</span>*&nbsp;<span class="varident">it</span>);
     </p>

--- a/libics.h
+++ b/libics.h
@@ -207,7 +207,7 @@ typedef struct _ICS {
         /* Size of the data buffer: */
     size_t                  dataLength;
         /* Pixel strides (writing only): */
-    const size_t           *dataStrides;
+    const ptrdiff_t        *dataStrides;
         /* '.ics' path/filename: */
     char                    filename[ICS_MAXPATHLEN];
         /* Number of elements in each dim: */
@@ -527,11 +527,11 @@ ICSEXPORT Ics_Error IcsGetROIData(ICS          *ics,
 /* Read the image from an ICS file into a sub-block of a memory block. To use
    the defaults in one of the parameters, set the pointer to NULL. Only valid if
    reading. */
-ICSEXPORT Ics_Error IcsGetDataWithStrides(ICS          *ics,
-                                          void         *dest,
-                                          size_t        n,
-                                          const size_t *stride,
-                                          int           nDims);
+ICSEXPORT Ics_Error IcsGetDataWithStrides(ICS             *ics,
+                                          void            *dest,
+                                          size_t           n, // ignored
+                                          const ptrdiff_t *stride,
+                                          int              nDims);
 
 
 /* Read a portion of the image data from an ICS file. Only valid if reading. */
@@ -562,11 +562,11 @@ ICSEXPORT Ics_Error IcsSetData(ICS        *ics,
 
 /* Set the image data for an ICS image. The pointer to this data must be
    accessible until IcsClose has been called. Only valid if writing. */
-ICSEXPORT Ics_Error IcsSetDataWithStrides(ICS          *ics,
-                                          const void   *src,
-                                          size_t        n,
-                                          const size_t *strides,
-                                          int           nDims);
+ICSEXPORT Ics_Error IcsSetDataWithStrides(ICS             *ics,
+                                          const void      *src,
+                                          size_t           n,
+                                          const ptrdiff_t *strides,
+                                          int              nDims);
 
 /* Set the image source parameter for an ICS version 2.0 file. Only valid if
    writing. */

--- a/libics.h
+++ b/libics.h
@@ -592,6 +592,14 @@ ICSEXPORT Ics_Error IcsGetPosition(const ICS *ics,
                                    double    *scale,
                                    char*      units);
 
+/* Idem, but without copying the strings. Output pointer `units` set to internal
+   buffer, which will be valid until IcsClose is called. */
+ICSEXPORT Ics_Error IcsGetPositionF(const ICS   *ics,
+                                    int          dimension,
+                                    double      *origin,
+                                    double      *scale,
+                                    const char **units);
+
 
 /* Set the position of the image in the real world: the origin of the first
    pixel, the distances between pixels and the units in which to measure.  If
@@ -611,6 +619,13 @@ ICSEXPORT Ics_Error IcsGetOrder(const ICS *ics,
                                 int        dimension,
                                 char      *order,
                                 char      *label);
+
+/* Idem, but without copying the strings. Output pointers `order` and `label` set
+   to internal buffer, which will be valid until IcsClose is called. */
+ICSEXPORT Ics_Error IcsGetOrderF(const ICS   *ics,
+                                 int          dimension,
+                                 const char **order,
+                                 const char **label);
 
 
 /* Set the ordering of the dimensions in the image. The ordering is defined by
@@ -652,6 +667,13 @@ ICSEXPORT Ics_Error IcsGetImelUnits(const ICS *ics,
                                     double    *origin,
                                     double    *scale,
                                     char      *units);
+
+/* Idem, but without copying the strings. Output pointer `units` set to internal
+   buffer, which will be valid until IcsClose is called. */
+ICSEXPORT Ics_Error IcsGetImelUnitsF(const ICS   *ics,
+                                     double      *origin,
+                                     double      *scale,
+                                     const char **units);
 
 
 /* Set the position of the pixel values: the offset and scaling, and the units
@@ -732,6 +754,12 @@ ICSEXPORT Ics_Error IcsGetHistoryStringI(ICS                 *ics,
                                          Ics_HistoryIterator *it,
                                          char                *string);
 
+/* Idem, but without copying the string. Output pointer `string` set to internal
+   buffer, which will be valid until IcsClose or IcsFreeHistory is called. */
+ICSEXPORT Ics_Error IcsGetHistoryStringIF(ICS                 *ics,
+                                          Ics_HistoryIterator *it,
+                                          const char         **string);
+
 
 /* Get history line from the ICS file as key/value pair using iterator.  key
    must have ICS_STRLEN_TOKEN characters allocated, and value
@@ -740,6 +768,13 @@ ICSEXPORT Ics_Error IcsGetHistoryKeyValueI(ICS                 *ics,
                                            Ics_HistoryIterator *it,
                                            char                *key,
                                            char                *value);
+
+/* Idem, but without copying the string. Output pointer `value` set to internal
+   buffer, which will be valid until IcsClose or IcsFreeHistory is called. */
+ICSEXPORT Ics_Error IcsGetHistoryKeyValueIF(ICS                 *ics,
+                                            Ics_HistoryIterator *it,
+                                            char                *key,
+                                            const char         **value);
 
 
 /* Delete last retrieved history line (iterator still points to the same

--- a/libics.h
+++ b/libics.h
@@ -43,6 +43,7 @@
 #ifndef LIBICS_H
 #define LIBICS_H
 
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -211,7 +212,7 @@ typedef struct _ICS {
     char                    filename[ICS_MAXPATHLEN];
         /* Number of elements in each dim: */
     int                     dimensions;
-        /* Image representaion: */
+        /* Image representation: */
     Ics_DataRepresentation  dim[ICS_MAXDIM];
         /* Pixel representation: */
     Ics_ImelRepresentation  imel;

--- a/libics_binary.c
+++ b/libics_binary.c
@@ -64,12 +64,12 @@
 
 
 /* Write uncompressed data, with strides. */
-Ics_Error IcsWritePlainWithStrides(const void   *src,
-                                   const size_t *dim,
-                                   const size_t *stride,
-                                   int           nDims,
-                                   int           nBytes,
-                                   FILE         *file)
+Ics_Error IcsWritePlainWithStrides(const void      *src,
+                                   const size_t    *dim,
+                                   const ptrdiff_t *stride,
+                                   int              nDims,
+                                   int              nBytes,
+                                   FILE            *file)
 {
     ICSINIT;
     size_t      curpos[ICS_MAXDIM];
@@ -84,7 +84,7 @@ Ics_Error IcsWritePlainWithStrides(const void   *src,
     while (1) {
         data = (char const*)src;
         for (i = 1; i < nDims; i++) {
-            data += curpos[i] * stride[i] * nBytes;
+            data += (ptrdiff_t)curpos[i] * stride[i] * nBytes;
         }
         if (stride[0] == 1) {
             if (fwrite(data, nBytes, dim[0], file) != dim[0]) {

--- a/libics_gzip.c
+++ b/libics_gzip.c
@@ -207,13 +207,13 @@ Ics_Error IcsWriteZip(const void *inBuf,
 
 
 /* Write ZIP compressed data, with strides. */
-Ics_Error IcsWriteZipWithStrides(const void   *src,
-                                 const size_t *dim,
-                                 const size_t *stride,
-                                 int           nDims,
-                                 int           nBytes,
-                                 FILE         *file,
-                                 int           level)
+Ics_Error IcsWriteZipWithStrides(const void      *src,
+                                 const size_t    *dim,
+                                 const ptrdiff_t *stride,
+                                 int              nDims,
+                                 int              nBytes,
+                                 FILE            *file,
+                                 int              level)
 {
 #ifdef ICS_ZLIB
     ICSINIT;
@@ -277,7 +277,7 @@ Ics_Error IcsWriteZipWithStrides(const void   *src,
     while (1) {
         data = (char const*)src;
         for (i = 1; i < nDims; i++) { /* curPos[0]==0 here */
-            data += curPos[i] * stride[i] * nBytes;
+            data += (ptrdiff_t)curPos[i] * stride[i] * nBytes;
         }
             /* Get data line */
         if (contiguousLine) {

--- a/libics_history.c
+++ b/libics_history.c
@@ -147,7 +147,7 @@ Ics_Error IcsInternAddHistory(Ics_Header *ics,
         char** tmp = (char**)realloc(hist->strings, n * sizeof(char*));
         if (tmp == NULL) return IcsErr_Alloc;
         hist->strings = tmp;
-        hist->length += ICS_HISTARRAY_INCREMENT;
+        hist->length = n;
     }
 
         /* Create line */
@@ -181,9 +181,12 @@ Ics_Error IcsGetNumHistoryStrings(ICS *ics,
 {
     ICSINIT;
     int          i, count = 0;
-    Ics_History *hist      = (Ics_History*)ics->history;
+    Ics_History *hist;
 
     if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
+
     *num = 0;
     if (hist == NULL) return IcsErr_Ok;
     for (i = 0; i < hist->nStr; i++) {
@@ -222,9 +225,11 @@ Ics_Error IcsNewHistoryIterator(ICS                 *ics,
                                 char const          *key)
 {
     ICSINIT;
-    Ics_History *hist = (Ics_History*)ics->history;
+    Ics_History *hist;
 
     if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
 
     it->next = -1;
     it->previous = -1;
@@ -301,9 +306,11 @@ Ics_Error IcsGetHistoryStringI(ICS                 *ics,
                                char                *string)
 {
     ICSINIT;
-    Ics_History *hist = (Ics_History*)ics->history;
+    Ics_History *hist;
 
     if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
 
     if (hist == NULL) return IcsErr_EndOfHistory;
     if ((it->next >= 0) &&(hist->strings[it->next] == NULL)) {
@@ -361,13 +368,14 @@ Ics_Error IcsDeleteHistory(ICS        *ics,
                            const char *key)
 {
     ICSINIT;
-    Ics_History *hist = (Ics_History*)ics->history;
+    Ics_History *hist;
 
+    if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
 
     if (hist == NULL) return IcsErr_Ok;
     if (hist->nStr == 0) return IcsErr_Ok;
-
-    if (ics == NULL) return IcsErr_NotValidAction;
 
     if ((key == NULL) ||(key[0] == '\0')) {
         int i;
@@ -406,10 +414,11 @@ Ics_Error IcsDeleteHistoryStringI(ICS                 *ics,
                                   Ics_HistoryIterator *it)
 {
     ICSINIT;
-    Ics_History *hist = (Ics_History*)ics->history;
-
+    Ics_History *hist;
 
     if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
 
     if (hist == NULL) return IcsErr_Ok;      /* give error message? */
     if (it->previous < 0) return IcsErr_Ok;
@@ -426,7 +435,7 @@ Ics_Error IcsDeleteHistoryStringI(ICS                 *ics,
     return error;
 }
 
-/* Delete last retrieved history line(iterator still points to the same
+/* Delete last retrieved history line (iterator still points to the same
    string). Contains code duplicated from IcsInternAddHistory(). */
 Ics_Error IcsReplaceHistoryStringI(ICS                 *ics,
                                    Ics_HistoryIterator *it,
@@ -436,10 +445,11 @@ Ics_Error IcsReplaceHistoryStringI(ICS                 *ics,
     ICSINIT;
     size_t       len;
     char        *line;
-    Ics_History *hist = (Ics_History*)ics->history;
-
+    Ics_History *hist;
 
     if (ics == NULL) return IcsErr_NotValidAction;
+
+    hist = (Ics_History*)ics->history;
 
     if (hist == NULL) return IcsErr_Ok;      /* give error message? */
     if (it->previous < 0) return IcsErr_Ok;

--- a/libics_intern.h
+++ b/libics_intern.h
@@ -246,12 +246,12 @@ Ics_Error IcsInternAddHistory(Ics_Header *ics,
 void IcsFillByteOrder(int bytes,
                       int machineByteOrder[ICS_MAX_IMEL_SIZE]);
 
-Ics_Error IcsWritePlainWithStrides(const void   *src,
-                                   const size_t *dim,
-                                   const size_t *stride,
-                                   int           nDims,
-                                   int           nBytes,
-                                   FILE         *file);
+Ics_Error IcsWritePlainWithStrides(const void      *src,
+                                   const size_t    *dim,
+                                   const ptrdiff_t *stride,
+                                   int              nDims,
+                                   int              nBytes,
+                                   FILE            *file);
 
 Ics_Error IcsCopyIds(const char *infilename,
                      size_t      inoffset,
@@ -263,13 +263,13 @@ Ics_Error IcsWriteZip(const void *src,
                       FILE       *fp,
                       int         CompLevel);
 
-Ics_Error IcsWriteZipWithStrides(const void   *src,
-                                 const size_t *dim,
-                                 const size_t *stride,
-                                 int           nDims,
-                                 int           nBytes,
-                                 FILE         *file,
-                                 int           level);
+Ics_Error IcsWriteZipWithStrides(const void      *src,
+                                 const size_t    *dim,
+                                 const ptrdiff_t *stride,
+                                 int              nDims,
+                                 int              nBytes,
+                                 FILE            *file,
+                                 int              level);
 
 Ics_Error IcsOpenZip(Ics_Header *IcsStruct);
 

--- a/libics_top.c
+++ b/libics_top.c
@@ -51,14 +51,17 @@
  *   IcsSetSource()
  *   IcsSetCompression()
  *   IcsGetPosition()
+ *   IcsGetPositionF()
  *   IcsSetPosition()
  *   IcsGetOrder()
+ *   IcsGetOrderF()
  *   IcsSetOrder()
  *   IcsGetCoordinateSystem()
  *   IcsSetCoordinateSystem()
  *   IcsGetSignificantBits()
  *   IcsSetSignificantBits()
  *   IcsGetImelUnits()
+ *   IcsGetImelUnitsF()
  *   IcsSetImelUnits()
  *   IcsGetScilType()
  *   IcsSetScilType()
@@ -759,6 +762,27 @@ Ics_Error IcsGetPosition(const ICS *ics,
                          char      *units)
 {
     ICSINIT;
+    const char* ptr;
+
+    error = IcsGetPositionF(ics, dimension, origin, scale, &ptr);
+    if (!error) {
+        if (units) {
+            strcpy(units, ptr);
+        }
+    }
+
+    return error;
+}
+
+/* Idem, but without copying the strings. Output pointer `units` set to internal
+   buffer, which will be valid until IcsClose is called. */
+Ics_Error IcsGetPositionF(const ICS   *ics,
+                          int          dimension,
+                          double      *origin,
+                          double      *scale,
+                          const char **units)
+{
+    ICSINIT;
 
 
     if (ics == NULL) return IcsErr_NotValidAction;
@@ -773,15 +797,14 @@ Ics_Error IcsGetPosition(const ICS *ics,
     }
     if (units) {
         if (ics->dim[dimension].unit[0] != '\0') {
-            strcpy(units, ics->dim[dimension].unit);
+            *units = ics->dim[dimension].unit;
         } else {
-            strcpy(units, ICS_UNITS_UNDEFINED);
+            *units = ICS_UNITS_UNDEFINED;
         }
     }
 
     return error;
 }
-
 
 /* Set the position of the image in the real world: the origin of the first
    pixel, the distances between pixels and the units in which to measure. If
@@ -821,16 +844,40 @@ Ics_Error IcsGetOrder(const ICS *ics,
                       char      *label)
 {
     ICSINIT;
+    const char *order_ptr;
+    const char *label_ptr;
+
+    error = IcsGetOrderF(ics, dimension, &order_ptr, &label_ptr);
+    if (!error) {
+        if (order) {
+            strcpy(order, order_ptr);
+        }
+        if (label) {
+            strcpy(label, label_ptr);
+        }
+    }
+
+    return error;
+}
+
+/* Idem, but without copying the strings. Output pointers `order` and `label` set
+   to internal buffer, which will be valid until IcsClose is called. */
+Ics_Error IcsGetOrderF(const ICS   *ics,
+                       int          dimension,
+                       const char **order,
+                       const char **label)
+{
+    ICSINIT;
 
 
     if (ics == NULL) return IcsErr_NotValidAction;
 
     if (dimension >= ics->dimensions) return IcsErr_NotValidAction;
     if (order) {
-        strcpy(order, ics->dim[dimension].order);
+        *order = ics->dim[dimension].order;
     }
     if (label) {
-        strcpy(label, ics->dim[dimension].label);
+        *label = ics->dim[dimension].label;
     }
 
     return error;
@@ -959,6 +1006,26 @@ Ics_Error IcsGetImelUnits(const ICS *ics,
                           char      *units)
 {
     ICSINIT;
+    const char* ptr;
+
+    error = IcsGetImelUnitsF(ics, origin, scale, &ptr);
+    if (!error) {
+        if (units) {
+            strcpy(units, ptr);
+        }
+    }
+
+    return error;
+}
+
+/* Idem, but without copying the strings. Output pointer `units` set to internal
+   buffer, which will be valid until IcsClose is called. */
+Ics_Error IcsGetImelUnitsF(const ICS   *ics,
+                           double      *origin,
+                           double      *scale,
+                           const char **units)
+{
+    ICSINIT;
 
 
     if (ics == NULL) return IcsErr_NotValidAction;
@@ -971,9 +1038,9 @@ Ics_Error IcsGetImelUnits(const ICS *ics,
     }
     if (units) {
         if (ics->imel.unit[0] != '\0') {
-            strcpy(units, ics->imel.unit);
+            *units = ics->imel.unit;
         } else {
-            strcpy(units, ICS_UNITS_RELATIVE);
+            *units = ICS_UNITS_RELATIVE;
         }
     }
 

--- a/libics_top.c
+++ b/libics_top.c
@@ -1122,7 +1122,7 @@ const char *IcsGetErrorText(Ics_Error error)
             msg = "Some error occurred during compression";
             break;
         case IcsErr_CorruptedStream:
-            msg = "The compressed input stream is currupted";
+            msg = "The compressed input stream is corrupted";
             break;
         case IcsErr_DecompressionProblem:
             msg = "Some error occurred during decompression";
@@ -1165,7 +1165,7 @@ const char *IcsGetErrorText(Ics_Error error)
             msg = "File read error on .ids file";
             break;
         case IcsErr_FTempMoveIcs:
-            msg = "Failed to remane .ics file opened for updating";
+            msg = "Failed to rename .ics file opened for updating";
             break;
         case IcsErr_FWriteIcs:
             msg = "File write error on .ics file";
@@ -1235,7 +1235,7 @@ const char *IcsGetErrorText(Ics_Error error)
             msg = "Unknown compression type";
             break;
         case IcsErr_UnknownDataType:
-            msg = "The datatype is not recognized";
+            msg = "The data type is not recognized";
             break;
         case IcsErr_UnknownSensorState:
             msg = "The state is not recognized";

--- a/test_strides.c
+++ b/test_strides.c
@@ -9,7 +9,7 @@ int main(int argc, const char* argv[]) {
    int          ndims;
    size_t       dims[ICS_MAXDIM];
    size_t       bufsize;
-   size_t       strides[3];
+   ptrdiff_t    strides[3];
    void*        buf1;
    void*        buf2;
    void*        buf3;
@@ -30,8 +30,8 @@ int main(int argc, const char* argv[]) {
    }
    IcsGetLayout(ip, &dt, &ndims, dims);
    strides[0] = 1;
-   strides[1] = dims[0]*dims[2];
-   strides[2] = dims[0];
+   strides[1] = (ptrdiff_t)(dims[0]*dims[2]);
+   strides[2] = (ptrdiff_t)dims[0];
    bufsize = IcsGetDataSize(ip);
    buf1 = malloc(bufsize);
    if (buf1 == NULL) {

--- a/test_strides2.sh
+++ b/test_strides2.sh
@@ -1,1 +1,1 @@
-./test_strides2 $srcdir/test/testim.ics result_s.ics
+./test_strides2 $srcdir/test/testim.ics result_s2.ics

--- a/test_strides3.c
+++ b/test_strides3.c
@@ -29,9 +29,9 @@ int main(int argc, const char* argv[]) {
       exit(-1);
    }
    IcsGetLayout(ip, &dt, &ndims, dims);
-   strides[0] = (ptrdiff_t)(dims[1]*2);
-   strides[1] = 2;
-   strides[2] = (ptrdiff_t)(dims[0]*dims[1]*2);
+   strides[0] = -1;
+   strides[1] = -(ptrdiff_t)(dims[0]*dims[2]);
+   strides[2] = -(ptrdiff_t)dims[0];
    bufsize = IcsGetDataSize(ip);
    buf1 = malloc(bufsize);
    if (buf1 == NULL) {
@@ -44,12 +44,12 @@ int main(int argc, const char* argv[]) {
               IcsGetErrorText(retval));
       exit(-1);
    }
-   buf3 = malloc(2*bufsize);
+   buf3 = malloc(bufsize);
    if (buf3 == NULL) {
       fprintf(stderr, "Could not allocate memory.\n");
       exit(-1);
    }
-   retval = IcsGetDataWithStrides(ip, buf3, 2*bufsize, strides, 3);
+   retval = IcsGetDataWithStrides(ip, buf3 + bufsize - 1, 0, strides, 3);
    if (retval != IcsErr_Ok) {
       fprintf(stderr, "Could not read input image data using strides: %s\n",
               IcsGetErrorText(retval));
@@ -70,7 +70,7 @@ int main(int argc, const char* argv[]) {
       exit(-1);
    }
    IcsSetLayout(ip, dt, ndims, dims);
-   IcsSetDataWithStrides(ip, buf3, 2*bufsize, strides, 3);
+   IcsSetDataWithStrides(ip, buf3 + bufsize - 1, bufsize, strides, 3);
    IcsSetCompression(ip, IcsCompr_gzip, 6);
    retval = IcsClose(ip);
    if (retval != IcsErr_Ok) {

--- a/test_strides3.sh
+++ b/test_strides3.sh
@@ -1,0 +1,1 @@
+./test_strides3 $srcdir/test/testim.ics result_s3.ics


### PR DESCRIPTION
I have separated these into 4 commits so you can take the ones you like.

1- C99 requires using `<stddef.h>` for `size_t`.

2- Several bug fixes: typos in documentation, and in `libics_history.c` we were dereferencing the `ics` pointer, and afterwards checking that the pointer is not `NULL`.

3- A string copy is not a whole lot of work, but it felt better to me to retrieve a pointer to a string rather than copying it.

4- I needed libics to support negative strides, so changed `size_t` for `ptrdiff_t` when related to strides. This adds a test program as well. I removed the tests for the data buffer size, since it doesn't work when you allow negative strides. This means that the buffer size parameter `n` for the functions `IcsGetDataWithStrides` and `IcsSetDataWithStrides` is currently ignored.