### PR TITLE
Improve build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ project(libics VERSION 1.6.1)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED on)
 # TODO: This flags works for GCC and CLang, not sure about other compilers
-set(CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG} "-Wall")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall")
 
 # Debug or Release?
-if(NOT CMAKE_CONFIGURATION_TYPES OR NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE Release)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,77 +10,143 @@
 #
 #   CMakeLists.txt
 #   Created by Paul Barber <paul.barber@oncology.ox.ac.uk>, Feb 2017
-#
-#   To aid building on Windows 10 and with Visual Studio 2015 (VC14).
-#   Requires libics.def
-#
-# To compile and build on Windows:
-# 	cmake CMakeLists.txt   OR use cmake GUI
-#   Open sln file in Visual Studio and build solution
-#
-# To compile and build on linux:
-# 	cmake CMakeLists.txt
-#   make
-#
-# To clean on linux:
-# 	make clean
-#
-# NOTE: This cmake file does very few configuration compared to the configure
-# script. Notably, it uses hard-coded definitions in libics_conf.h.in and only
-# tests for existence of the strcascmp() function. This appears to work on
-# current versions of windows and Linux. The configure script remains the
-# recommended method for compiling libics, where-ever that is
-# feasible. Scientific Volume Image does guarantee continuing support for the
-# cmake files.
+#   Heavily modified by Cris Luengo, July 2017
 #
 ##############################################################################
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 
-project(libics)
+project(libics VERSION 1.6.1)
 
-set(USE_ZLIB TRUE CACHE BOOL "Use Zlib")
+# Note: the version number above is not yet used anywhere.
+# TODO: rewrite the header file with this version number.
+# The line below does not work: we need the installed header file to contain the version number also.
+#add_definitions(-DICSLIB_VERSION="${libics_VERSION}")
 
+# Compiler flags
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED on)
+# TODO: This flags works for GCC and CLang, not sure about other compilers
+set(CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG} "-Wall")
+
+# Debug or Release?
+if(NOT CMAKE_CONFIGURATION_TYPES OR NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Zlib
+find_package(ZLIB)
+if(ZLIB_FOUND)
+   set(USE_ZLIB TRUE CACHE BOOL "Use Zlib")
+endif()
 if(USE_ZLIB)
-    find_path(ZLIB_PATH zlib.h ${CMAKE_SOURCE_DIR}/zlib)
-	find_library(ZLIB_LIB NAMES zlib libz.so HINTS ${ZLIB_PATH} ${ZLIB_PATH}/build ${ZLIB_PATH}/build/Release)
-	find_library(ZLIB_STATIC_LIB NAMES zlibstatic libz.a HINTS ${ZLIB_PATH} ${ZLIB_PATH}/build ${ZLIB_PATH}/build/Release)
-    include_directories(${ZLIB_PATH})
-    add_definitions(-DICS_ZLIB)
-endif(USE_ZLIB)
+   include_directories(${ZLIB_INCLUDE_DIRS})
+   add_definitions(-DICS_ZLIB)
+endif()
 
+# ICS
 configure_file(libics_conf.h.in ${CMAKE_SOURCE_DIR}/libics_conf.h COPYONLY)
+set(SOURCES
+      libics_binary.c
+      libics_compress.c
+      libics_data.c
+      libics_gzip.c
+      libics_history.c
+      libics_preview.c
+      libics_read.c
+      libics_sensor.c
+      libics_test.c
+      libics_top.c
+      libics_util.c
+      libics_write.c
+      libics_conf.h
+      )
 
-set (SOURCES libics_read.c
-          libics_write.c
-          libics_binary.c
-          libics_gzip.c
-          libics_compress.c
-          libics_data.c
-          libics_util.c
-          libics_top.c
-          libics_history.c
-          libics_preview.c
-          libics_sensor.c
-          libics_test.c
-          libics.def
-)
+set(HEADERS
+      libics.h
+      libics_intern.h
+      libics_ll.h
+      libics_sensor.h
+      libics_test.h
+      )
 
 include_directories(${CMAKE_SOURCE_DIR})
 
-include(CheckFunctionExists)
-check_function_exists(strcasecmp HAVE_STRCASECMP)
-if(HAVE_STRCASECMP)
-  add_definitions(-DHAVE_STRING_STRCASECMP)
-endif(HAVE_STRCASECMP)
-  
 # Build a dll
-add_library(libics SHARED ${SOURCES})
+add_library(libics SHARED ${SOURCES} ${HEADERS})
+target_compile_definitions(libics PRIVATE BUILD_ICSLIB) # For Windows, when compiling DLL
+target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # For Windows, when linking against DLL
 
 # Build a static library
-add_library(libics_static STATIC ${SOURCES})
+add_library(libics_static STATIC ${SOURCES} ${HEADERS})
 
+# Link against zlib
 if(USE_ZLIB)
-    target_link_libraries(libics ${ZLIB_LIB})
-    target_link_libraries(libics_static ${ZLIB_STATIC_LIB})
-endif(USE_ZLIB)
+    target_link_libraries(libics ${ZLIB_LIBRARIES})
+    target_link_libraries(libics_static ${ZLIB_LIBRARIES})
+endif()
 
+# Install
+install(TARGETS libics libics_static DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include)
+
+# Unit tests
+enable_testing()
+add_executable(test_ics1 EXCLUDE_FROM_ALL test_ics1.c)
+target_link_libraries(test_ics1 libics)
+add_executable(test_ics2a EXCLUDE_FROM_ALL test_ics2a.c)
+target_link_libraries(test_ics2a libics)
+add_executable(test_ics2b EXCLUDE_FROM_ALL test_ics2b.c)
+target_link_libraries(test_ics2b libics)
+add_executable(test_gzip EXCLUDE_FROM_ALL test_gzip.c)
+target_link_libraries(test_gzip libics)
+add_executable(test_compress EXCLUDE_FROM_ALL test_compress.c)
+target_link_libraries(test_compress libics)
+add_executable(test_strides EXCLUDE_FROM_ALL test_strides.c)
+target_link_libraries(test_strides libics)
+add_executable(test_strides2 EXCLUDE_FROM_ALL test_strides2.c)
+target_link_libraries(test_strides2 libics)
+add_executable(test_strides3 EXCLUDE_FROM_ALL test_strides3.c)
+target_link_libraries(test_strides3 libics)
+add_executable(test_metadata EXCLUDE_FROM_ALL test_metadata.c)
+target_link_libraries(test_metadata libics)
+add_executable(test_history EXCLUDE_FROM_ALL test_history.c)
+target_link_libraries(test_history libics)
+add_custom_target(all_tests DEPENDS
+      test_ics1
+      test_ics2a
+      test_ics2b
+      test_gzip
+      test_compress
+      test_strides
+      test_strides2
+      test_strides3
+      test_metadata
+      test_history
+      )
+add_test(ctest_build_test_code "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target all_tests)
+add_test(NAME test_ics1 COMMAND test_ics1 ${CMAKE_SOURCE_DIR}/test/testim.ics result_v1.ics)
+set_tests_properties(test_ics1 PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_ics2a COMMAND test_ics2a ${CMAKE_SOURCE_DIR}/test/testim.ics result_v2a.ics)
+set_tests_properties(test_ics2a PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_ics2b COMMAND test_ics2b ${CMAKE_SOURCE_DIR}/test/testim.ics result_v2b.ics)
+set_tests_properties(test_ics2b PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_gzip COMMAND test_gzip ${CMAKE_SOURCE_DIR}/test/testim.ics result_v2z.ics)
+set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_compress COMMAND test_compress ${CMAKE_SOURCE_DIR}/test/testim.ics ${CMAKE_SOURCE_DIR}/test/testim_c.ics)
+set_tests_properties(test_compress PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_strides COMMAND test_strides ${CMAKE_SOURCE_DIR}/test/testim.ics result_s.ics)
+set_tests_properties(test_strides PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_strides2 COMMAND test_strides2 ${CMAKE_SOURCE_DIR}/test/testim.ics result_s2.ics)
+set_tests_properties(test_strides2 PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_strides3 COMMAND test_strides3 ${CMAKE_SOURCE_DIR}/test/testim.ics result_s3.ics)
+set_tests_properties(test_strides3 PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_metadata1 COMMAND test_metadata result_v1.ics)
+set_tests_properties(test_metadata1 PROPERTIES DEPENDS test_ics1)
+add_test(NAME test_metadata2 COMMAND test_metadata result_v2a.ics)
+set_tests_properties(test_metadata2 PROPERTIES DEPENDS test_ics2a)
+add_test(NAME test_metadata3 COMMAND test_metadata result_v2b.ics)
+set_tests_properties(test_metadata3 PROPERTIES DEPENDS test_ics2b)
+add_test(NAME test_metadata4 COMMAND test_metadata result_v2z.ics)
+set_tests_properties(test_metadata4 PROPERTIES DEPENDS test_gzip)
+add_test(NAME test_history COMMAND test_history result_v1.ics)
+set_tests_properties(test_history PROPERTIES DEPENDS test_ics1)

--- a/README
+++ b/README
@@ -100,12 +100,26 @@ libics.dll.lib. To make a debug version add '/D DEBUG' to these
 commands. To disable zlib support, remove the definition of ZLIB_SUPPORT
 from the file Makefile.vc.
 
+ - Compilation with CMake under UNIX / Linux / Mac OS X / Cygwin
 
-- Compilation with cmake.
+Run the following commands from outside the source directory
+   cmake <path/to/libics/sources>
+   make
+   make install
 
-A CMakeLists.txt file present to support the use of cmake, which may work when
-the above options fail. Consult the cmake documentation for general instructions
-on how to use cmake, and read the notes in CMakeLists.txt.
+The library can be tested for problems using
+   make test
+
+CMake can be used with the following options:
+   cmake ... -DCMAKE_BUILD_TYPE=Debug
+   cmake ... -DUSE_ZLIB=Off
+
+ - Compilation with cmake on Windows:
+
+Type on the command line
+   cmake CMakeLists.txt
+or use cmake GUI. Next, open sln file in Visual Studio and build solution.
+
 
    CREDITS
 =============

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # only needed if you change Makefile.am or configure.in
 
 autoreconf --install --force

--- a/config.h.in
+++ b/config.h.in
@@ -18,9 +18,6 @@
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
 
-/* Define to 1 if you have the `strcasecmp' function. */
-#undef HAVE_STRCASECMP
-
 /* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H
 
@@ -71,36 +68,6 @@
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
-
-/* The size of `char', as computed by sizeof. */
-#undef SIZEOF_CHAR
-
-/* The size of `double', as computed by sizeof. */
-#undef SIZEOF_DOUBLE
-
-/* The size of `float', as computed by sizeof. */
-#undef SIZEOF_FLOAT
-
-/* The size of `int', as computed by sizeof. */
-#undef SIZEOF_INT
-
-/* The size of `long', as computed by sizeof. */
-#undef SIZEOF_LONG
-
-/* The size of `short', as computed by sizeof. */
-#undef SIZEOF_SHORT
-
-/* The size of `unsigned char', as computed by sizeof. */
-#undef SIZEOF_UNSIGNED_CHAR
-
-/* The size of `unsigned int', as computed by sizeof. */
-#undef SIZEOF_UNSIGNED_INT
-
-/* The size of `unsigned long', as computed by sizeof. */
-#undef SIZEOF_UNSIGNED_LONG
-
-/* The size of `unsigned short', as computed by sizeof. */
-#undef SIZEOF_UNSIGNED_SHORT
 
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS

--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,6 @@ AC_TYPE_SIZE_T
 # If this variable is not defined, libics_conf.h will revert to the old version.
 AC_DEFINE([ICS_USING_CONFIGURE], [], [Using the configure script.])
 
-dnl Check for proper include file for strcasecmp
-AC_CHECK_FUNCS([strcasecmp])
-
 dnl Check if you want to use .ids.gz and .ids.Z extensions
 AC_ARG_ENABLE(gzext, AS_HELP_STRING([--disable-gz-extensions], [disable .ids.gz and .ids.Z extensions (enabled by default)]),,)
 
@@ -112,18 +109,6 @@ dnl ---------------------------------------------------------------------------
 
 dnl Check for -lm:
 AC_CHECK_LIB(m, sqrt, [], [AC_MSG_ERROR([math lib is required])])
-
-dnl Get the sizes of the types in bytes:
-AC_CHECK_SIZEOF(char, 0)
-AC_CHECK_SIZEOF(unsigned char, 0)
-AC_CHECK_SIZEOF(short, 0)
-AC_CHECK_SIZEOF(unsigned short, 0)
-AC_CHECK_SIZEOF(int, 0)
-AC_CHECK_SIZEOF(unsigned int, 0)
-AC_CHECK_SIZEOF(long, 0)
-AC_CHECK_SIZEOF(unsigned long, 0)
-AC_CHECK_SIZEOF(float, 0)
-AC_CHECK_SIZEOF(double, 0)
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/libics_conf.h.in
+++ b/libics_conf.h.in
@@ -53,7 +53,7 @@
 
 
 /* ICS_BUF_SIZE is the size of the buffer allocated to:
-   - Do the compression. This is independend from the memory allocated by zlib
+   - Do the compression. This is independent from the memory allocated by zlib
      for the dictionary.
    - Decompress stuff into when skipping a data block (IcsSetIdsBlock() for
      compressed files).
@@ -62,13 +62,27 @@
 #define ICS_BUF_SIZE 16384
 
 
-/*********************************************************************
- *** If we are not using the configure script:                     ***
- *** (currently configured for 32-bit Windows - edit as necessary) ***
- *********************************************************************/
+/* These are used internally when the precise length of a variable is needed.
+   We also use size_t for a variable that is as wide as a pointer
+   (i.e. can hold the size of any data block).
+ */
+#include <stdint.h>
+typedef uint8_t  ics_t_uint8;
+typedef int8_t   ics_t_sint8;
+typedef uint16_t ics_t_uint16;
+typedef int16_t  ics_t_sint16;
+typedef uint32_t ics_t_uint32;
+typedef int32_t  ics_t_sint32;
+typedef float ics_t_real32;
+typedef double ics_t_real64;
+
 
 #undef ICS_USING_CONFIGURE
 #if !defined(ICS_USING_CONFIGURE)
+
+/*********************************************************************
+ *** If we are not using the autoconf configure script:
+ *********************************************************************/
 
 /* If ICS_FORCE_C_LOCALE is set, the locale is set to "C" before each read or
    write operation. This ensures that the ICS header file is formatted
@@ -86,152 +100,26 @@
 #define ICS_DO_GZEXT
 
 
-/* If ICS_ZLIB is defined, the zlib dependancy is included, and the library will
+/* If ICS_ZLIB is defined, the zlib dependency is included, and the library will
    be able to read GZIP compressed files.  This variable is set by the makefile
    -- enable ZLIB support there. */
 /*#define ICS_ZLIB*/
 
 
-/* These are used internally when the precise length of a variable is needed.
-   These are OK for 32-bit systems, but they might be different for 64-bit
-   systems.  We also use size_t for a variable that is as wide as a pointer
-   (i.e. can hold the size of any data block).
- */
-typedef unsigned char ics_t_uint8;
-typedef signed char ics_t_sint8;
-typedef unsigned short ics_t_uint16;
-typedef signed short ics_t_sint16;
-typedef unsigned int ics_t_uint32;
-typedef signed int ics_t_sint32;
-typedef float ics_t_real32;
-typedef double ics_t_real64;
-
-
-/*********************************************************************
- *** If we are using the configure script:
- *********************************************************************/
 #else
 
-/* Define if your system has strcasecmp() in strings.h */
-#undef HAVE_STRCASECMP
+/*********************************************************************
+ *** If we are using the autoconf configure script:
+ *********************************************************************/
 
 /* If we should force the c locale. */
 #undef ICS_FORCE_C_LOCALE
-
-/* Location of the . */
-#undef ICS_DO_GZEXT
 
 /* Whether to search for IDS files with .ids.gz or .ids.Z extension. */
 #undef ICS_DO_GZEXT
 
 /* Whether to use zlib compression. */
 #undef ICS_ZLIB
-
-/* The number of bytes in a char.  */
-#undef SIZEOF_CHAR
-
-/* The number of bytes in a short.  */
-#undef SIZEOF_SHORT
-
-/* The number of bytes in a int.  */
-#undef SIZEOF_INT
-
-/* The number of bytes in a long.  */
-#undef SIZEOF_LONG
-
-/* The number of bytes in a unsigned char.  */
-#undef SIZEOF_UNSIGNED_CHAR
-
-/* The number of bytes in a unsigned short.  */
-#undef SIZEOF_UNSIGNED_SHORT
-
-/* The number of bytes in a unsigned int.  */
-#undef SIZEOF_UNSIGNED_INT
-
-/* The number of bytes in a unsigned long.  */
-#undef SIZEOF_UNSIGNED_LONG
-
-/* The number of bytes in a float.  */
-#undef SIZEOF_FLOAT
-
-/* The number of bytes in a double.  */
-#undef SIZEOF_DOUBLE
-
-/* These are used internally when the precise length of a variable is needed.
-   We also use size_t for a variable that is as wide as a pointer (i.e. can hold
-   the size of any data block). */
-
-#if SIZEOF_CHAR == 1
-typedef signed char ics_t_sint8;
-#elif SIZEOF_SHORT == 1
-typedef signed short ics_t_sint8;
-#elif SIZEOF_INT == 1
-typedef signed int ics_t_sint8;
-#elif SIZEOF_LONG == 1
-typedef signed long ics_t_sint8;
-#endif
-
-#if SIZEOF_UNSIGNED_CHAR == 1
-typedef unsigned char ics_t_uint8;
-#elif SIZEOF_UNSIGNED_SHORT == 1
-typedef unsigned short ics_t_uint8;
-#elif SIZEOF_UNSIGNED_INT == 1
-typedef unsigned int ics_t_uint8;
-#elif SIZEOF_UNSIGNED_LONG == 1
-typedef unsigned long ics_t_uint8;
-#endif
-
-#if SIZEOF_CHAR == 2
-typedef signed char ics_t_sint16;
-#elif SIZEOF_SHORT == 2
-typedef signed short ics_t_sint16;
-#elif SIZEOF_INT == 2
-typedef signed int ics_t_sint16;
-#elif SIZEOF_LONG == 2
-typedef signed long ics_t_sint16;
-#endif
-
-#if SIZEOF_UNSIGNED_CHAR == 2
-typedef unsigned char ics_t_uint16;
-#elif SIZEOF_UNSIGNED_SHORT == 2
-typedef unsigned short ics_t_uint16;
-#elif SIZEOF_UNSIGNED_INT == 2
-typedef unsigned int ics_t_uint16;
-#elif SIZEOF_UNSIGNED_LONG == 2
-typedef unsigned long ics_t_uint16;
-#endif
-
-#if SIZEOF_CHAR == 4
-typedef signed char ics_t_sint32;
-#elif SIZEOF_SHORT == 4
-typedef signed short ics_t_sint32;
-#elif SIZEOF_INT == 4
-typedef signed int ics_t_sint32;
-#elif SIZEOF_LONG == 4
-typedef signed long ics_t_sint32;
-#endif
-
-#if SIZEOF_UNSIGNED_CHAR == 4
-typedef unsigned char ics_t_uint32;
-#elif SIZEOF_UNSIGNED_SHORT == 4
-typedef unsigned short ics_t_uint32;
-#elif SIZEOF_UNSIGNED_INT == 4
-typedef unsigned int ics_t_uint32;
-#elif SIZEOF_UNSIGNED_LONG == 4
-typedef unsigned long ics_t_uint32;
-#endif
-
-#if SIZEOF_FLOAT == 4
-typedef float ics_t_real32;
-#elif SIZEOF_DOUBLE == 4
-typedef double ics_t_real32;
-#endif
-
-#if SIZEOF_FLOAT == 8
-typedef float ics_t_real64;
-#elif SIZEOF_DOUBLE == 8
-typedef double ics_t_real64;
-#endif
 
 #endif
 

--- a/libics_util.c
+++ b/libics_util.c
@@ -58,12 +58,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#endif
-
-#ifdef HAVE_STRCASECMP
-#include <strings.h>
+#define strcasecmp _stricmp
 #else
-#define strcasecmp stricmp
+#include <strings.h>   /* For strcasecmp() */
 #endif
 
 const char ICSEXT[] = ".ics";


### PR DESCRIPTION
One more try for the improved CMake build, this time without removing the autoconf stuff.

The first commit simplifies configuration: the `strcasecmp` function is found as in this morning's email, and fixed-width integer types use C99 standard ones instead of complex configure scripting and conditional compilation. This means that the code should now compile directly on any platform, configuration now just creates a Makefile.

The second commit adds back the CMakeLists.txt file that I wrote last week, with some further tweaks. Note that this CMake script will not work correctly unless the first commit is applied also: it relies on the configuration simplifications made there.

I have not tested the CMakeLists.txt file on Windows, I recommend someone does so.

I have also not updated any of the autoconf and automake-generated files in the repository. When I run `bootstrap.sh` it overwrites a lot of the tools with a slightly newer version, and I didn't want to put all of that in the pull request.