### PR TITLE
Modernized CMakeLists, fixed compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .deps/
 .libs/
 *.la

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,22 +25,26 @@ project(libics VERSION 1.6.2)
 # Compiler flags
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED on)
-# TODO: This flags works for GCC and CLang, not sure about other compilers
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall")
+
+if (CMAKE_C_COMPILER_ID MATCHES "Clang") # also matchs "AppleClang"
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wall -Wconversion -Wsign-conversion")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -Wno-unused-parameter")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Intel")
+    # TODO: compiler flags for Intel compiler
+elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    # TODO: compiler flags for MSVC compiler
+endif()
 
 # Debug or Release?
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-   set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 # Zlib
 find_package(ZLIB)
 if(ZLIB_FOUND)
-   set(USE_ZLIB TRUE CACHE BOOL "Use Zlib")
-endif()
-if(USE_ZLIB)
-   include_directories(${ZLIB_INCLUDE_DIRS})
-   add_definitions(-DICS_ZLIB)
+    set(LIBICS_USE_ZLIB TRUE CACHE BOOL "Use Zlib in libics")
 endif()
 
 # ICS
@@ -69,26 +73,30 @@ set(HEADERS
       libics_test.h
       )
 
-include_directories(${PROJECT_SOURCE_DIR})
-
 # Build a dll
 add_library(libics SHARED ${SOURCES} ${HEADERS})
 target_compile_definitions(libics PRIVATE BUILD_ICSLIB) # For Windows, when compiling DLL
 target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # For Windows, when linking against DLL
+target_include_directories(libics PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 if (UNIX)
     set_target_properties(libics PROPERTIES OUTPUT_NAME "ics")
 endif (UNIX)
 
 # Build a static library
 add_library(libics_static STATIC ${SOURCES} ${HEADERS})
+target_include_directories(libics_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 if (UNIX)
     set_target_properties(libics_static PROPERTIES OUTPUT_NAME "ics")
 endif (UNIX)
 
 # Link against zlib
-if(USE_ZLIB)
-    target_link_libraries(libics ${ZLIB_LIBRARIES})
-    target_link_libraries(libics_static ${ZLIB_LIBRARIES})
+if(LIBICS_USE_ZLIB)
+    target_link_libraries(libics PUBLIC ${ZLIB_LIBRARIES})
+    target_include_directories(libics PRIVATE ${ZLIB_INCLUDE_DIRS})
+    target_compile_definitions(libics PRIVATE -DICS_ZLIB)
+    target_link_libraries(libics_static PUBLIC ${ZLIB_LIBRARIES})
+    target_include_directories(libics_static PRIVATE ${ZLIB_INCLUDE_DIRS})
+    target_compile_definitions(libics_static PRIVATE -DICS_ZLIB)
 endif()
 
 # Install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(ZLIB_FOUND)
 endif()
 
 # ICS
-configure_file(libics_conf.h.in ${PROJECT_SOURCE_DIR}/libics_conf.h COPYONLY)
+configure_file(libics_conf.h.in ${CMAKE_CURRENT_SOURCE_DIR}/libics_conf.h COPYONLY)
 set(SOURCES
       libics_binary.c
       libics_compress.c
@@ -137,22 +137,22 @@ add_custom_target(all_tests DEPENDS
       test_metadata
       test_history
       )
-add_test(ctest_build_test_code "${CMAKE_COMMAND}" --build ${PROJECT_BINARY_DIR} --target all_tests)
-add_test(NAME test_ics1 COMMAND test_ics1 ${PROJECT_SOURCE_DIR}/test/testim.ics result_v1.ics)
+add_test(ctest_build_test_code "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target all_tests)
+add_test(NAME test_ics1 COMMAND test_ics1 "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v1.ics)
 set_tests_properties(test_ics1 PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_ics2a COMMAND test_ics2a ${PROJECT_SOURCE_DIR}/test/testim.ics result_v2a.ics)
+add_test(NAME test_ics2a COMMAND test_ics2a "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2a.ics)
 set_tests_properties(test_ics2a PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_ics2b COMMAND test_ics2b ${PROJECT_SOURCE_DIR}/test/testim.ics result_v2b.ics)
+add_test(NAME test_ics2b COMMAND test_ics2b "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2b.ics)
 set_tests_properties(test_ics2b PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_gzip COMMAND test_gzip ${PROJECT_SOURCE_DIR}/test/testim.ics result_v2z.ics)
+add_test(NAME test_gzip COMMAND test_gzip "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2z.ics)
 set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_compress COMMAND test_compress ${PROJECT_SOURCE_DIR}/test/testim.ics ${PROJECT_SOURCE_DIR}/test/testim_c.ics)
+add_test(NAME test_compress COMMAND test_compress "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" "${CMAKE_CURRENT_SOURCE_DIR}/test/testim_c.ics")
 set_tests_properties(test_compress PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_strides COMMAND test_strides ${PROJECT_SOURCE_DIR}/test/testim.ics result_s.ics)
+add_test(NAME test_strides COMMAND test_strides "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_s.ics)
 set_tests_properties(test_strides PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_strides2 COMMAND test_strides2 ${PROJECT_SOURCE_DIR}/test/testim.ics result_s2.ics)
+add_test(NAME test_strides2 COMMAND test_strides2 "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_s2.ics)
 set_tests_properties(test_strides2 PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_strides3 COMMAND test_strides3 ${PROJECT_SOURCE_DIR}/test/testim.ics result_s3.ics)
+add_test(NAME test_strides3 COMMAND test_strides3 "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_s3.ics)
 set_tests_properties(test_strides3 PROPERTIES DEPENDS ctest_build_test_code)
 add_test(NAME test_metadata1 COMMAND test_metadata result_v1.ics)
 set_tests_properties(test_metadata1 PROPERTIES DEPENDS test_ics1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,15 @@ include_directories(${PROJECT_SOURCE_DIR})
 add_library(libics SHARED ${SOURCES} ${HEADERS})
 target_compile_definitions(libics PRIVATE BUILD_ICSLIB) # For Windows, when compiling DLL
 target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # For Windows, when linking against DLL
+if (UNIX)
+    set_target_properties(libics PROPERTIES OUTPUT_NAME "ics")
+endif (UNIX)
 
 # Build a static library
 add_library(libics_static STATIC ${SOURCES} ${HEADERS})
+if (UNIX)
+    set_target_properties(libics_static PROPERTIES OUTPUT_NAME "ics")
+endif (UNIX)
 
 # Link against zlib
 if(USE_ZLIB)

--- a/README
+++ b/README
@@ -113,7 +113,15 @@ The library can be tested for problems using
 
 CMake can be used with the following options:
    cmake ... -DCMAKE_BUILD_TYPE=Debug
-   cmake ... -DUSE_ZLIB=Off
+   cmake ... -DLIBICS_USE_ZLIB=Off
+
+CMake projects using libics as a subproject can do
+   add_subdirectory(<path/to/libics/sources>)
+   target_link_libraries(target PRIVATE libics)
+or
+   target_link_libraries(target PRIVATE libics_static)
+The include directory for libics will be automatically set, and the ZLib
+library will be linked if necessary.
 
  - Compilation with cmake on Windows:
 

--- a/libics_binary.c
+++ b/libics_binary.c
@@ -87,12 +87,12 @@ Ics_Error IcsWritePlainWithStrides(const void      *src,
             data += (ptrdiff_t)curpos[i] * stride[i] * nBytes;
         }
         if (stride[0] == 1) {
-            if (fwrite(data, nBytes, dim[0], file) != dim[0]) {
+            if (fwrite(data, (size_t)nBytes, dim[0], file) != dim[0]) {
                 return IcsErr_FWriteIds;
             }
         } else {
             for (j = 0; j < dim[0]; j++) {
-                if (fwrite(data, nBytes, 1, file) != 1) {
+                if (fwrite(data, (size_t)nBytes, 1, file) != 1) {
                     return IcsErr_FWriteIds;
                 }
                 data += stride[0] * nBytes;
@@ -149,7 +149,7 @@ Ics_Error IcsWriteIds(const Ics_Header *icsStruct)
                 error = IcsWritePlainWithStrides(icsStruct->data, dim,
                                                  icsStruct->dataStrides,
                                                  icsStruct->dimensions,
-                                                 size, fp);
+                                                 (int)size, fp);
             } else {
                     /* We do the writing in blocks if the data is very large,
                        this avoids a bug in some c library implementations on
@@ -180,7 +180,7 @@ Ics_Error IcsWriteIds(const Ics_Header *icsStruct)
                 error = IcsWriteZipWithStrides(icsStruct->data, dim,
                                                icsStruct->dataStrides,
                                                icsStruct->dimensions,
-                                               size, fp, icsStruct->compLevel);
+                                               (int)size, fp, icsStruct->compLevel);
             } else {
                 error = IcsWriteZip(icsStruct->data, icsStruct->dataLength, fp,
                                     icsStruct->compLevel);
@@ -218,7 +218,7 @@ Ics_Error IcsCopyIds(const char *infilename,
         error = IcsErr_FCopyIds;
         goto exit;
     }
-    if (fseek(in, inoffset, SEEK_SET) != 0) {
+    if (fseek(in, (long)inoffset, SEEK_SET) != 0) {
         error = IcsErr_FCopyIds;
         goto exit;
     }
@@ -315,14 +315,15 @@ static Ics_Error IcsReorderIds(char   *buf,
                                int     bytes)
 {
     ICSINIT;
-    int  i, j, imels;
+    int  i;
+    size_t j, imels;
     int  dstByteOrder[ICS_MAX_IMEL_SIZE];
     char imel[ICS_MAX_IMEL_SIZE];
     int  different = 0, empty = 0;
 
 
-    imels = length / bytes;
-    if (length % bytes != 0) return IcsErr_BitsVsSizeConfl;
+    imels = length / (size_t)bytes;
+    if (length % (size_t)bytes != 0) return IcsErr_BitsVsSizeConfl;
 
         /* Create destination byte order: */
     IcsFillByteOrder(bytes, dstByteOrder);
@@ -393,7 +394,7 @@ Ics_Error IcsOpenIds(Ics_Header *icsStruct)
 
     br->dataFilePtr = IcsFOpen(filename, "rb");
     if (br->dataFilePtr == NULL) return IcsErr_FOpenIds;
-    if (fseek(br->dataFilePtr, offset, SEEK_SET) != 0) {
+    if (fseek(br->dataFilePtr, (long)offset, SEEK_SET) != 0) {
         fclose(br->dataFilePtr);
         free(br);
         return IcsErr_FReadIds;
@@ -493,7 +494,7 @@ Ics_Error IcsReadIdsBlock(Ics_Header *icsStruct,
 Ics_Error IcsSkipIdsBlock(Ics_Header *icsStruct,
                           size_t      n)
 {
-    return IcsSetIdsBlock (icsStruct, n, SEEK_CUR);
+    return IcsSetIdsBlock (icsStruct, (long)n, SEEK_CUR);
 }
 
 

--- a/libics_compress.c
+++ b/libics_compress.c
@@ -178,7 +178,7 @@ Ics_Error IcsReadCompress(Ics_Header *IcsStruct,
 
       resetbuf:
 
-        offset = posBits >> 3;
+        offset = (size_t)(posBits >> 3);
         inSize = offset <= inSize ? inSize - offset : 0;
         for (i = 0 ; i < inSize ; ++i) {
             inBuffer[i] = inBuffer[i + offset];
@@ -195,9 +195,9 @@ Ics_Error IcsReadCompress(Ics_Header *IcsStruct,
         }
 
         if (rSize > 0) {
-            inBits = (inSize - inSize%nBits) << 3;
+            inBits = (int)((inSize - inSize%(size_t)nBits) << 3);
         } else {
-            inBits = (inSize << 3) - (nBits - 1);
+            inBits = (int)((inSize << 3) - (size_t)(nBits - 1));
         }
 
         while (inBits > posBits) {
@@ -261,7 +261,7 @@ Ics_Error IcsReadCompress(Ics_Header *IcsStruct,
             *--stackPtr = (unsigned char)fInChar;
 
                 /* And put them out in forward order */
-            i = DE_STACK - stackPtr;
+            i = (size_t)(DE_STACK - stackPtr);
             if (outPos+i > len) {
                 i = len-outPos; /* do not write more in buffer than fits! */
             }

--- a/libics_conf.h.in
+++ b/libics_conf.h.in
@@ -67,7 +67,7 @@ typedef double   ics_t_real64;
 
 
 /* ICS_BUF_SIZE is the size of the buffer allocated to:
-   - Do the compression. This is independend from the memory allocated by zlib
+   - Do the compression. This is independent from the memory allocated by zlib
      for the dictionary.
    - Decompress stuff into when skipping a data block (IcsSetIdsBlock() for
      compressed files).
@@ -76,13 +76,13 @@ typedef double   ics_t_real64;
 #define ICS_BUF_SIZE 16384
 
 
-/*********************************************************************
- *** If we are not using the configure script:                     ***
- *** (currently configured for 32-bit Windows - edit as necessary) ***
- *********************************************************************/
-
 #undef ICS_USING_CONFIGURE
 #if !defined(ICS_USING_CONFIGURE)
+
+/*********************************************************************/
+/* If we are not using the configure script:                         */
+/*********************************************************************/
+
 
 /* If ICS_FORCE_C_LOCALE is set, the locale is set to "C" before each read or
    write operation. This ensures that the ICS header file is formatted
@@ -100,7 +100,7 @@ typedef double   ics_t_real64;
 #define ICS_DO_GZEXT
 
 
-/* If ICS_ZLIB is defined, the zlib dependancy is included, and the library will
+/* If ICS_ZLIB is defined, the zlib dependency is included, and the library will
    be able to read GZIP compressed files.  This variable is set by the makefile
    -- enable ZLIB support there. */
 /*#define ICS_ZLIB*/

--- a/libics_gzip.c
+++ b/libics_gzip.c
@@ -163,7 +163,7 @@ Ics_Error IcsWriteZip(const void *inBuf,
     totalCount = 0;
     do {
         if (len - totalCount < ICS_BUF_SIZE) {
-            stream.avail_in = len - totalCount;
+            stream.avail_in = (uInt)(len - totalCount);
         } else {
             stream.avail_in = ICS_BUF_SIZE;
         }
@@ -235,7 +235,7 @@ Ics_Error IcsWriteZipWithStrides(const void      *src,
     if (outBuf == Z_NULL) return IcsErr_Alloc;
         /* Create an input buffer */
     if (!contiguousLine) {
-        inBuf = (Byte*)malloc(dim[0] * nBytes);
+        inBuf = (Byte*)malloc(dim[0] * (size_t)nBytes);
         if (inBuf == Z_NULL) {
             free(outBuf);
             return IcsErr_Alloc;
@@ -285,14 +285,14 @@ Ics_Error IcsWriteZipWithStrides(const void      *src,
         } else {
             inBuf_ptr = inBuf;
             for (j = 0; j < dim[0]; j++) {
-                memcpy(inBuf_ptr, data, nBytes);
+                memcpy(inBuf_ptr, data, (size_t)nBytes);
                 data += stride[0] * nBytes;
                 inBuf_ptr += nBytes;
             }
         }
             /* Write the compressed data */
         stream.next_in = (Bytef*)inBuf;
-        stream.avail_in = dim[0] * nBytes;
+        stream.avail_in = (uInt)(dim[0] * (size_t)nBytes);
         totalCount += stream.avail_in;
         while (stream.avail_in != 0) {
             if (stream.avail_out == 0) {
@@ -313,7 +313,7 @@ Ics_Error IcsWriteZipWithStrides(const void      *src,
             error = IcsErr_CompressionProblem;
             goto error_exit;
         }
-        crc = crc32(crc, (Bytef*)inBuf, dim[0] * nBytes);
+        crc = crc32(crc, (Bytef*)inBuf, (uInt)(dim[0] * (size_t)nBytes));
             /* This is part of the N-D loop */
         for (i = 1; i < nDims; i++) {
             curPos[i]++;
@@ -396,7 +396,7 @@ Ics_Error IcsOpenZip(Ics_Header *icsStruct)
         len  =  (uInt)getc(file);
         len += ((uInt)getc(file)) << 8;
         if (feof (file)) return IcsErr_CorruptedStream;
-        fseek(file, len, SEEK_CUR);
+        fseek(file, (long)len, SEEK_CUR);
     }
     if ((flags & ORIG_NAME) != 0) {   /* skip the original file name */
         int c;
@@ -497,7 +497,7 @@ Ics_Error IcsReadZipBlock(Ics_Header *icsStruct,
 
         /* Read the compressed data */
     do {
-        stream->avail_in = fread(inBuf, 1, ICS_BUF_SIZE, file);
+        stream->avail_in = (uInt)fread(inBuf, 1, ICS_BUF_SIZE, file);
         if (ferror(file)) {
             return IcsErr_FReadIds;
         }
@@ -511,7 +511,7 @@ Ics_Error IcsReadZipBlock(Ics_Header *icsStruct,
                 err = Z_OK;
                 break;
             }
-            bufsize = todo < ICS_BUF_SIZE ? todo : ICS_BUF_SIZE;
+            bufsize = (unsigned int)(todo < ICS_BUF_SIZE ? todo : ICS_BUF_SIZE);
             stream->avail_out = bufsize;
             prevbuf = stream->next_out = (Bytef*)outBuf + len - todo;;
             err = inflate(stream, Z_NO_FLUSH);
@@ -567,7 +567,7 @@ Ics_Error IcsSetZipBlock(Ics_Header *icsStruct,
     z_stream*      stream = (z_stream*)br->zlibStream;
 
     if ((whence == SEEK_CUR) && (offset<0)) {
-        offset += stream->total_out;
+        offset += (long)stream->total_out;
         whence = SEEK_SET;
     }
     if (whence == SEEK_SET) {
@@ -579,11 +579,11 @@ Ics_Error IcsSetZipBlock(Ics_Header *icsStruct,
         if (offset==0) return IcsErr_Ok;
     }
 
-    bufsize = offset < ICS_BUF_SIZE ? offset : ICS_BUF_SIZE;
+    bufsize = (unsigned int)(offset < ICS_BUF_SIZE ? offset : ICS_BUF_SIZE);
     buf = malloc(bufsize);
     if (buf == NULL) return IcsErr_Alloc;
 
-    n = offset;
+    n = (size_t)offset;
     while (n > 0) {
         if (n > bufsize) {
             error = IcsReadZipBlock(icsStruct, buf, bufsize);

--- a/libics_history.c
+++ b/libics_history.c
@@ -205,7 +205,7 @@ Ics_Error IcsGetNumHistoryStrings(ICS *ics,
 static void IcsIteratorNext(Ics_History         *hist,
                             Ics_HistoryIterator *it)
 {
-    int nchar = strlen(it->key);
+    size_t nchar = strlen(it->key);
     it->previous = it->next;
     it->next++;
     if (nchar > 0) {
@@ -238,7 +238,7 @@ Ics_Error IcsNewHistoryIterator(ICS                 *ics,
     if ((key == NULL) ||(key[0] == '\0')) {
         it->key[0] = '\0';
     } else {
-        int n;
+        size_t n;
         IcsStrCpy(it->key, key, ICS_STRLEN_TOKEN);
             /* Append a \t, so that the search for the key finds whole words */
         n = strlen(it->key);
@@ -382,7 +382,7 @@ Ics_Error IcsGetHistoryKeyValueIF(ICS                 *ics,
     if (error) return error;
 
     ptr = strchr(buf, ICS_FIELD_SEP);
-    length = ptr-buf;
+    length = (size_t)(ptr-buf);
     if ((ptr != NULL) &&(length > 0) &&(length < ICS_STRLEN_TOKEN)) {
         if (key != NULL) {
             memcpy(key, buf, length);

--- a/libics_preview.c
+++ b/libics_preview.c
@@ -118,7 +118,7 @@ Ics_Error IcsGetPreviewData(ICS    *ics,
         sizeConflict = 1;
         if (n < roiSize) return IcsErr_BufferTooSmall;
     }
-    bps = IcsGetBytesPerSample(ics);
+    bps = (size_t)IcsGetBytesPerSample(ics);
     if (bps > 1) {
         buf = malloc (roiSize * bps);
         if (buf == NULL) return IcsErr_Alloc;
@@ -228,7 +228,7 @@ Ics_Error IcsGetPreviewData(ICS    *ics,
         {
             ics_t_uint32 *in = buf;
             ics_t_uint8 *out = dest;
-            int offset; double gain;
+            ics_t_uint32 offset; double gain;
             ics_t_uint32 max = *in, min = *in;
             in++;
             for (i = 1; i < roiSize; i++, in++) {

--- a/libics_read.c
+++ b/libics_read.c
@@ -146,8 +146,8 @@ static Ics_Error getIcsSeparators(FILE *fi,
             }
         }
     }
-    seps[0] = sep1;
-    seps[1] = sep2;
+    seps[0] = (char)sep1;
+    seps[1] = (char)sep2;
     seps[2] = '\0';
 
     return IcsErr_Ok;
@@ -359,7 +359,8 @@ Ics_Error IcsReadIcs(Ics_Header *icsStruct,
     ICSINIT;
     ICS_INIT_LOCALE;
     FILE            *fp;
-    int              end        = 0, i, j, bits;
+    int              end        = 0, si, sj;
+    size_t           i, j;
     char             seps[3], *ptr, *data;
     char             line[ICS_LINE_LENGTH];
     Ics_Token        cat, subCat, subSubCat;
@@ -861,33 +862,33 @@ Ics_Error IcsReadIcs(Ics_Header *icsStruct,
            files in which a single microscope type is defined and multiple
            sensor channels, the microscope type will be duplicated to all sensor
            channels. */
-    for (j = 1; j < icsStruct->sensorChannels; j++) {
-        if (strlen(icsStruct->type[j]) == 0) {
-            IcsStrCpy(icsStruct->type[j], icsStruct->type[0],
+    for (sj = 1; sj < icsStruct->sensorChannels; sj++) {
+        if (strlen(icsStruct->type[sj]) == 0) {
+            IcsStrCpy(icsStruct->type[sj], icsStruct->type[0],
                        ICS_STRLEN_TOKEN);
         }
     }
 
     if (!error) {
-        bits = icsGetBitsParam(order, parameters);
+        int bits = icsGetBitsParam(order, parameters);
         if (bits < 0) {
             error = IcsErr_MissBits;
         } else {
             IcsGetDataTypeProps(&(icsStruct->imel.dataType), format, sign,
                                 sizes[bits]);
-            for (j = 0, i = 0; i < parameters; i++) {
-                if (i == bits) {
-                    icsStruct->imel.origin = origin[i];
+            for (sj = 0, si = 0; si < parameters; si++) {
+                if (si == bits) {
+                    icsStruct->imel.origin = origin[si];
                     icsStruct->imel.scale = scale[i];
-                    strcpy(icsStruct->imel.unit, unit[i]);
+                    strcpy(icsStruct->imel.unit, unit[si]);
                 } else {
-                    icsStruct->dim[j].size = sizes[i];
-                    icsStruct->dim[j].origin = origin[i];
-                    icsStruct->dim[j].scale = scale[i];
-                    strcpy(icsStruct->dim[j].order, order[i]);
-                    strcpy(icsStruct->dim[j].label, label[i]);
-                    strcpy(icsStruct->dim[j].unit, unit[i]);
-                    j++;
+                    icsStruct->dim[sj].size = sizes[si];
+                    icsStruct->dim[sj].origin = origin[si];
+                    icsStruct->dim[sj].scale = scale[si];
+                    strcpy(icsStruct->dim[sj].order, order[si]);
+                    strcpy(icsStruct->dim[sj].label, label[si]);
+                    strcpy(icsStruct->dim[sj].unit, unit[si]);
+                    sj++;
                 }
             }
             icsStruct->dimensions = parameters - 1;

--- a/libics_sensor.c
+++ b/libics_sensor.c
@@ -819,7 +819,7 @@ Ics_Error IcsSetSensorParameter(ICS                 *ics,
             ics->lambdaEmState[channel] = state;
             break;
         case ICS_SENSOR_PHOTON_COUNT:
-            ics->exPhotonCnt[channel] = value;
+            ics->exPhotonCnt[channel] = (int)value;
             ics->exPhotonCntState[channel] = state;
             break;
         case ICS_SENSOR_INTERFACE_PRIMARY:

--- a/libics_top.c
+++ b/libics_top.c
@@ -280,7 +280,7 @@ size_t IcsGetDataSize(const ICS *ics)
 {
     if (ics == NULL) return 0;
     if (ics->dimensions == 0) return 0;
-    return IcsGetImageSize(ics) * IcsGetBytesPerSample(ics);
+    return IcsGetImageSize(ics) * (size_t)IcsGetBytesPerSample(ics);
 }
 
 
@@ -288,7 +288,7 @@ size_t IcsGetDataSize(const ICS *ics)
 size_t IcsGetImelSize(const ICS *ics)
 {
     if (ics != NULL) {
-        return IcsGetBytesPerSample(ics);
+        return (size_t)IcsGetBytesPerSample(ics);
     } else {
         return 0;
     }
@@ -429,7 +429,7 @@ Ics_Error IcsGetROIData(ICS          *ics,
         if (sampling[i] < 1 || offset[i] + size[i] > ics->dim[i].size)
             return IcsErr_IllegalROI;
     }
-    imelSize = IcsGetBytesPerSample(ics);
+    imelSize = (size_t)IcsGetBytesPerSample(ics);
     roiSize = imelSize;
     for (i = 0; i < p; i++) {
         roiSize *= (size[i] + sampling[i] - 1) / sampling[i];
@@ -472,7 +472,7 @@ Ics_Error IcsGetROIData(ICS          *ics,
             }
             curLoc += bufSize;
             for (j=0; j < size[0]; j += sampling[0]) {
-                memcpy(dest, buf + i * imelSize, imelSize);
+                memcpy(dest, buf + (unsigned)i * imelSize, imelSize);
                 dest += imelSize;
             }
             for (i = 1; i < p; i++) {
@@ -567,7 +567,7 @@ Ics_Error IcsGetDataWithStrides(ICS             *ics,
         }
         stride = b_stride;
     }
-    imelSize = IcsGetBytesPerSample(ics);
+    imelSize = (size_t)IcsGetBytesPerSample(ics);
 
     error = IcsOpenIds(ics);
     if (error) return error;

--- a/libics_util.c
+++ b/libics_util.c
@@ -127,8 +127,8 @@ void IcsStrCpy(char       *dest,
                int         len)
 {
     if (dest != src) {
-        int nchar = strlen(src);
-        nchar =(nchar > len-1) ? len-1 : nchar;
+        size_t nchar = strlen(src);
+        nchar = (nchar > (size_t)len-1) ? (size_t)len-1 : nchar;
         memcpy(dest, src, nchar);
         dest[nchar] = 0;
     }
@@ -139,7 +139,7 @@ void IcsStrCpy(char       *dest,
 void IcsAppendChar(char *line,
                    char  ch)
 {
-    int len = strlen(line);
+    size_t len = strlen(line);
     line[len] = ch;
     line[len+1] = '\0';
 }
@@ -176,7 +176,7 @@ static char *IcsFileNameFind(const char *str)
  extension could be found. */
 char *IcsExtensionFind(const char *str)
 {
-    int         len;
+    size_t     len;
     const char *ext;
 
 
@@ -437,7 +437,7 @@ void IcsInit(Ics_Header *icsStruct)
 /* Find the number of bytes per sample. */
 int IcsGetBytesPerSample(const Ics_Header *icsStruct)
 {
-    return IcsGetDataTypeSize(icsStruct->imel.dataType);
+    return (int)IcsGetDataTypeSize(icsStruct->imel.dataType);
 }
 
 
@@ -489,6 +489,7 @@ void IcsGetPropsDataType(Ics_DataType  dataType,
         case Ics_uint16:
         case Ics_uint32:
             *sign = 0;
+            /* fallthrough */
         case Ics_sint8:
         case Ics_sint16:
         case Ics_sint32:

--- a/libics_write.c
+++ b/libics_write.c
@@ -353,7 +353,7 @@ static Ics_Error writeIcsSource(Ics_Header *icsStruct,
                                 FILE       *fp)
 {
     ICSINIT;
-    int  problem;
+    unsigned int  problem;
     char line[ICS_LINE_LENGTH];
 
 
@@ -383,7 +383,8 @@ static Ics_Error writeIcsLayout(Ics_Header *icsStruct,
                                 FILE       *fp)
 {
     ICSINIT;
-    int    problem, i;
+    unsigned int    problem;
+    int    i;
     char   line[ICS_LINE_LENGTH];
     size_t size;
 
@@ -459,7 +460,8 @@ static Ics_Error writeIcsRep(Ics_Header *icsStruct,
                              FILE       *fp)
 {
     ICSINIT;
-    int        problem, empty, i;
+    unsigned int    problem;
+    int        empty, i;
     char       line[ICS_LINE_LENGTH];
     Ics_Format format;
     int        sign;
@@ -531,7 +533,7 @@ static Ics_Error writeIcsRep(Ics_Header *icsStruct,
         empty |= !(icsStruct->byteOrder[i]);
     }
     if (empty) {
-        IcsFillByteOrder(IcsGetDataTypeSize(icsStruct->imel.dataType),
+        IcsFillByteOrder((int)IcsGetDataTypeSize(icsStruct->imel.dataType),
                          icsStruct->byteOrder);
     }
     problem = icsFirstToken(line, ICSTOK_REPRES);
@@ -562,7 +564,8 @@ static Ics_Error writeIcsParam(Ics_Header *icsStruct,
                                FILE       *fp)
 {
     ICSINIT;
-    int  problem, i;
+    unsigned int    problem;
+    int  i;
     char line[ICS_LINE_LENGTH];
 
 
@@ -716,7 +719,8 @@ static Ics_Error writeIcsSensorData(Ics_Header *icsStruct,
                                     FILE       *fp)
 {
     ICSINIT;
-    int  problem, i, chans;
+    unsigned int    problem;
+    int  i, chans;
     char line[ICS_LINE_LENGTH];
 
 
@@ -837,7 +841,8 @@ static Ics_Error writeIcsSensorStates(Ics_Header *icsStruct,
                                       FILE       *fp)
 {
     ICSINIT;
-    int             problem, i, chans;
+    unsigned int    problem;
+    int             i, chans;
     char            line[ICS_LINE_LENGTH];
     Ics_SensorState state;
 
@@ -895,7 +900,8 @@ static Ics_Error writeIcsHistory(Ics_Header *icsStruct,
                                  FILE       *fp)
 {
     ICSINIT;
-    int          problem, i;
+    unsigned int problem;
+    int          i;
     char         line[ICS_LINE_LENGTH];
     Ics_History* hist = (Ics_History*)icsStruct->history;
 


### PR DESCRIPTION
Two things in this pull request:

- CMakeLists.txt now uses the more modern approach of tagging the target with include directories and library dependencies, so that when linking against it those things are set automatically. I've also fixed a few little things in it.

- Fixed the code to silence the most strict compiler warnings. This did show that I made a mess back in the day with `int` and `unsigned` and `size_t`. It would be nice to align all types some day, but that's a lot of work, and might break code that uses libics.
