### PR TITLE
For evaluation: the proposed Ics_Ra* functions for ROI read/write access

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,13 +31,15 @@ libics_la_SOURCES = libics_binary.c \
                     libics_top.c \
                     libics_util.c \
                     libics_write.c \
+                    libics_random_access.c \
                     libics_intern.h
 
 # list all include files that must be installed and distributed:
 include_HEADERS = libics.h \
                   libics_ll.h \
                   libics_sensor.h \
-                  libics_test.h
+                  libics_test.h \
+                  libics_random_access.h
 
 # list all test programs
 check_PROGRAMS = test_ics1 \

--- a/Makefile.bcc
+++ b/Makefile.bcc
@@ -53,7 +53,8 @@ LIBOBJECTS = libics_read.obj \
              libics_history.obj \
              libics_preview.obj \
              libics_sensor.obj \
-             libics_test.obj
+             libics_test.obj \
+             libics_random_access.obj
 
 #
 # Options

--- a/Makefile.vc6
+++ b/Makefile.vc6
@@ -54,7 +54,8 @@ LIBOBJECTS = libics_read.obj \
              libics_history.obj \
              libics_preview.obj \
              libics_sensor.obj \
-             libics_test.obj
+             libics_test.obj \
+             libics_random_access.obj
 
 #
 # Options

--- a/Makefile.vc9
+++ b/Makefile.vc9
@@ -64,7 +64,8 @@ SOURCES = libics_read.obj \
           libics_history.obj \
           libics_preview.obj \
           libics_sensor.obj \
-          libics_test.obj
+          libics_test.obj \
+          libics_random_access.obj
 
 #
 # Options

--- a/libics.h
+++ b/libics.h
@@ -462,7 +462,18 @@ typedef enum {
     IcsErr_UnknownSensorState,
         /* libics is linking to a different version of zlib than used during
            compilation: */
-    IcsErr_WrongZlibVersion
+    IcsErr_WrongZlibVersion,
+        /* Attempting to write to a read-only file */
+    IcsErr_FReadOnly,
+        /* Mismatch between dimensionality of ICS file and parameter */
+    IcsErr_DimensionalityMismatch,
+        /* The random access functions require ics v2 or higher */
+    IcsErr_Version2Required,
+        /* The random access functions require a single ics file (no separate
+           ids and no file referral using the filename field) */
+    IcsErr_RaSingleFileRequired,
+        /* The random access function only work on uncompressed data */
+    IcsErr_RaOnlyUncompressedDataSupported
 } Ics_Error;
 
 

--- a/libics_intern.h
+++ b/libics_intern.h
@@ -221,6 +221,13 @@ typedef struct {
                                       been called */
 } Ics_BlockRead;
 
+/* Passed to IcsReadIcs() to accommodate the Ics_Ra* functions.
+ */
+typedef enum {
+  IcsOpenMode_ics,          /* Used by IcsOpen(), the standard/original mode */
+  IcsOpenMode_raRead,       /* Open file in read-only mode; return FILE handle */
+  IcsOpenMode_raReadWrite   /* Open file in read-write mode; return FILE handle */
+} Ics_OpenMode;
 
 /* Assorted support functions */
 FILE *IcsFOpen(const char *path,
@@ -242,12 +249,23 @@ void IcsGetFileName(char       *dest,
 
 Ics_Error IcsOpenIcs(FILE **fpp,
                      char  *filename,
-                     int    forceName);
+                     int    forceName,
+                     char  *mode);
 
 Ics_Error IcsInternAddHistory(Ics_Header *ics,
                               const char *key,
                               const char *stuff,
                               const char *seps);
+
+Ics_Error IcsReadIcsLow(Ics_Header       *icsStruct,
+                        const char       *filename,
+                        int               forceName,
+                        int               forceLocale,
+                        Ics_OpenMode      openMode,
+                        FILE            **fpret);
+Ics_Error IcsWriteIcsLow(Ics_Header  *icsStruct,
+                         const char  *filename,
+                         FILE       **fpra);
 
 /* Binary data support functions */
 void IcsFillByteOrder(Ics_DataType dataType,

--- a/libics_random_access.c
+++ b/libics_random_access.c
@@ -1,0 +1,505 @@
+/*
+ * libics: Image Cytometry Standard file reading and writing.
+ *
+ * Copyright 2015-2018:
+ *   Scientific Volume Imaging Holding B.V.
+ *   Laapersveld 63, 1213 VB Hilversum, The Netherlands
+ *   https://www.svi.nl
+ *
+ * Copyright (C) 2018 Michael van Ginkel
+ *
+ * Large chunks of this library written by
+ *    Bert Gijsbers
+ *    Dr. Hans T.M. van der Voort
+ * And also Damir Sudar, Geert van Kempen, Jan Jitze Krol,
+ * Chiel Baarslag and Fons Laan.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.`
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * FILE : libics_random_access.c
+ *
+ * The following library functions are contained in this file:
+ *
+ *   Ics_RaOpen()
+ *   Ics_RaClose()
+ *   Ics_RaReadOrWrite()
+ *   Ics_RaCreate()
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+#include "libics_random_access.h"
+#include "libics_intern.h"
+
+#define ICSXJ( call ) if (( error = call ) != IcsErr_Ok ) goto ics_error;
+
+typedef struct {
+  /* FILE specs */
+  FILE          *fp;
+  size_t         fend;
+  /* buffer specs */
+  unsigned char *buffer;
+  size_t         length;    /* in bytes */
+  size_t         position;  /* position of buffer[0] in file */
+  /* state */
+  Ics_FileMode   mode;
+  size_t         ndata;     /* amount of valid bytes are in the buffer */
+} ReadwriteBuffer;
+
+
+static void setByteOrderMap(ICSRA *icsra, int *isNop)
+{
+    ICS *ics;
+    int nbytes, ii, machOrder[ICS_MAX_IMEL_SIZE], map[ICS_MAX_IMEL_SIZE];
+
+    ics = &(icsra->ics);
+    nbytes = IcsGetBytesPerSample( ics );
+    IcsFillByteOrder(ics->imel.dataType, nbytes, machOrder);
+
+    for ( ii=0; ii<nbytes; ii++ ) {
+        map[ics->byteOrder[ii]-1] = ii;
+    }
+    *isNop = 1;
+    for ( ii=0; ii<nbytes; ii++ ) {
+        icsra->bomap[ii] = map[machOrder[ii]-1];
+        *isNop = *isNop && (icsra->bomap[ii] == ii);
+    }
+}
+
+/* Create an ICSRA structure. Read the ICS header and keep the file
+ * descriptor open for random access */
+Ics_Error Ics_RaOpen(ICSRA      **p_icsra,
+                     const char  *filename,
+                     const char  *mode)
+{
+    ICSINIT;
+    ICSRA       *icsra;
+    int          forceName = 0, forceLocale = 1, isNop;
+    size_t       ii;
+    Ics_OpenMode openMode = IcsOpenMode_raReadWrite;
+
+    ii = 0;
+    if ( strlen(mode)>=2 && mode[0] == 'r' ) {
+      if ( mode[1] == 'o' ) {
+        openMode = IcsOpenMode_raRead;
+        ii = 2;
+      }
+      if ( mode[1] == 'w' ) {
+        ii = 2;
+      }
+    }
+    /* the remaining mode string can containing "f" and/or "l" */
+    for ( ; ii<strlen(mode); ii++) {
+        switch (mode[ii]) {
+            case 'f':
+                if (forceName) return IcsErr_IllParameter;
+                forceName = 1;
+                break;
+            case 'l':
+                if (forceLocale) return IcsErr_IllParameter;
+                forceLocale = 0;
+                break;
+            default:
+                return IcsErr_IllParameter;
+        }
+    }
+    *p_icsra =(ICSRA*)malloc(sizeof(ICSRA));
+    if (*p_icsra == NULL) return IcsErr_Alloc;
+    icsra = *p_icsra;
+    icsra->readOnly = (openMode == IcsOpenMode_raRead ) ? 1 : 0;
+    /* also tests for version>1 and single .ics containing header+data */
+    error = IcsReadIcsLow(&(icsra->ics), filename, forceName, forceLocale,
+                          openMode, &(icsra->fp));
+    if (!error && icsra->ics.compression != IcsCompr_uncompressed) {
+        error = IcsErr_RaOnlyUncompressedDataSupported;
+    }
+    setByteOrderMap(icsra, &isNop);
+
+    if (error) {
+        free(*p_icsra);
+        *p_icsra = NULL;
+    }
+
+    return error;
+}
+
+Ics_Error Ics_RaClose(ICSRA *icsra)
+{
+    ICSINIT;
+    if ( icsra == NULL ) return error;
+    if ( icsra->fp != NULL && fclose(icsra->fp) == EOF ) {
+        error = IcsErr_FCloseIcs;
+    }
+    free(icsra);
+    return error;
+}
+
+static Ics_Error initialiseBuffer(ReadwriteBuffer   *buffer,
+                                  const int          dm,
+                                  const size_t      *dims,
+                                  const int          elsize,
+                                  FILE              *fp,
+                                  const size_t       fileOffset,
+                                  const Ics_FileMode mode)
+{
+    size_t maxBufferSize = ICS_MAX_IMEL_SIZE*(4*1024*1024/ICS_MAX_IMEL_SIZE);
+    size_t bufferSize;
+    int ii;
+
+    if ( (mode != IcsFileMode_write) && (mode != IcsFileMode_read) ) {
+        return IcsErr_IllParameter;
+    }
+
+    bufferSize = dims[0] * elsize;
+    for ( ii=1; ii<dm; ii++ ) bufferSize *= dims[ii];
+    buffer->fp = fp;
+    buffer->fend = fileOffset + bufferSize;
+    bufferSize = (bufferSize < maxBufferSize) ? bufferSize : maxBufferSize;
+    buffer->buffer = (unsigned char *)malloc(bufferSize);
+    if ( !buffer->buffer ) return IcsErr_Alloc;
+    buffer->length = bufferSize;
+    buffer->position = fileOffset;
+    buffer->ndata = 0;
+    buffer->mode = mode;
+    return IcsErr_Ok;
+}
+
+static Ics_Error writeBuffer(ReadwriteBuffer *buffer)
+{
+    size_t written;
+
+    if ( buffer->ndata == 0 ) return IcsErr_Ok;
+
+    if (fseek(buffer->fp,buffer->position,SEEK_SET)) {
+        return IcsErr_FWriteIds;
+    }
+    written = fwrite( buffer->buffer,1,buffer->ndata,buffer->fp);
+    if ( written != buffer->ndata ) {
+        return IcsErr_FWriteIds;
+    }
+    return IcsErr_Ok;
+}
+
+static Ics_Error updateBuffer(ReadwriteBuffer *buffer,
+                              size_t *bof,
+                              size_t *boe)
+{
+    ICSINIT;
+    size_t bytesToRead;
+    size_t read;
+
+    /* write buffer to disk if needed */
+    if ( buffer->mode == IcsFileMode_write ) {
+        error = writeBuffer(buffer);
+        if ( error != IcsErr_Ok ) return error;
+    }
+
+    buffer->position += *bof;
+    if (fseek(buffer->fp,buffer->position,SEEK_SET)) {
+        return IcsErr_FReadIds;
+    }
+    bytesToRead = buffer->fend - buffer->position;
+    if ( bytesToRead > buffer->length ) bytesToRead = buffer->length;
+    read = fread( buffer->buffer,1,bytesToRead,buffer->fp);
+    if ( read != bytesToRead) {
+        return IcsErr_FReadIds;
+    }
+    *bof = 0;
+    *boe = bytesToRead;
+    buffer->ndata = bytesToRead;
+
+    return IcsErr_Ok;
+}
+
+
+static void reorder(const int     dm,
+                    ptrdiff_t    *array,
+                    const size_t *order)
+{
+    size_t sorted[ICS_MAXDIM];
+    int ii;
+    for ( ii=0; ii<dm; ii++ ) {
+        sorted[ii] = array[order[ii]];
+    }
+    for ( ii=0; ii<dm; ii++ ) {
+        array[ii] = sorted[ii];
+    }
+}
+
+static void optimiseProcessingOrder(const int  dm,
+                                    size_t    *dims,
+                                    ptrdiff_t *f_stride,
+                                    ptrdiff_t *i_stride,
+                                    size_t    *f_offset,
+                                    size_t    *i_offset)
+{
+    size_t order[ICS_MAXDIM];
+    int ii, jj, in_order = 1;
+
+    /* first ensure all f_stride>0 */
+    for ( ii=0; ii<dm; ii++ ) {
+        if ( f_stride[ii]>=0 ) continue;
+        f_stride[ii] = -f_stride[ii];
+        i_stride[ii] = -i_stride[ii];
+        *f_offset -= f_stride[ii]*(ptrdiff_t)(dims[ii]-1);
+        *i_offset -= i_stride[ii]*(ptrdiff_t)(dims[ii]-1);
+        if ( ii>0 && f_stride[ii]<f_stride[ii-1] ) in_order = 0;
+    }
+    if ( in_order ) return;
+    /* find the order in which the strides are sorted */
+    order[0] = 0;
+    for ( ii=1; ii<dm; ii++ ) {
+        order[ii] = ii;
+        for ( jj=ii-1; jj>=0; jj-- ) {
+            if ( f_stride[order[jj]] < f_stride[ii] )
+                break;
+            order[jj+1] = order[jj];
+        }
+        order[jj+1] = ii;
+    }
+    /* re-order the file strides from small to large */
+    reorder( dm, f_stride, order );
+    reorder( dm, i_stride, order );
+    reorder( dm, (ptrdiff_t *)dims, order );
+}
+
+static void computeStrides(const int     dm,
+                           const size_t *dims,
+                           size_t       *stride)
+{
+    int ii;
+
+    stride[0] = 1;
+    for ( ii=1; ii<dm; ii++ ) {
+      stride[ii] = stride[ii-1]*dims[ii-1];
+    }
+}
+
+static size_t computeOffset(const int     dm,
+                            const size_t *origin,
+                            const size_t *stride)
+{
+    int ii;
+    size_t offset = 0;
+
+    if ( origin == NULL ) return 0;
+    for ( ii=0; ii<dm; ii++ ) {
+      offset += origin[ii]*stride[ii];
+    }
+    return offset;
+}
+
+static void computeFinalStrides(const int     dm,
+                                const int     elsize,
+                                const size_t *stride,
+                                const size_t *interval,
+                                ptrdiff_t    *step)
+{
+    int ii;
+    ptrdiff_t d_step;
+
+    for ( ii=0; ii<dm; ii++ ) {
+        d_step = (ptrdiff_t) stride[ii] * elsize;
+        step[ii] = interval ? d_step * interval[ii] : d_step;
+    }
+}
+
+
+/* the integer arithmetic below can overflow and is not bullet-proof */
+static Ics_Error checkLimits(const int        dm, 
+                             const size_t    *dims,
+                             const size_t    *fl_origin,
+                             const size_t    *fl_dims,
+                             const ptrdiff_t *fl_interval )
+{
+    int ii;
+    ptrdiff_t limL, limH;
+
+    for ( ii=0; ii<dm; ii++ ) {
+        limL = fl_origin ? fl_origin[ii] : 0;
+        limH = limL + ( fl_interval ? fl_interval[ii] : 1 ) *
+                      (ptrdiff_t)( fl_dims ? fl_dims[ii]-1 : dims[ii]-1 );
+        if ((size_t)limL >= dims[ii]) return IcsErr_IllegalROI;
+        if (limH<0)                   return IcsErr_IllegalROI;
+        if ((size_t)limH >= dims[ii]) return IcsErr_IllegalROI;
+    }
+    return IcsErr_Ok;
+}
+
+
+/* notes:
+ * - dm is only passed as an extra verification step. It should have been
+ *   obtained through Ics_GetLayout() by the caller. All fl_ and im_ parameters
+ *   can be NULL.
+ * - im_dims  is NOT a required parameter. If given, it is used to
+ *   check im_origin and im_interval (these are otherwise not checked)
+ */
+Ics_Error Ics_RaReadOrWrite(const ICSRA        *icsra,
+                            const int           pdm,
+                            const size_t       *rg_dims,
+                            const size_t       *fl_origin,
+                            const ptrdiff_t    *fl_interval,
+                            const void         *image,
+                            const size_t       *im_dims,
+                            const size_t       *im_stride,
+                            const size_t       *im_origin,
+                            const ptrdiff_t    *im_interval,
+                            const Ics_FileMode  mode)
+{
+    ICSINIT;
+    const ICS *ics;
+    Ics_DataType dt;
+    int dm, ii, jj, ci;
+    size_t elsize, fl_dims[ICS_MAXDIM], r_dims[ICS_MAXDIM], fl_stride[ICS_MAXDIM];
+    size_t f_offset, i_offset, cors[ICS_MAXDIM], boe;
+    ptrdiff_t f_stride[ICS_MAXDIM], i_stride[ICS_MAXDIM];
+    ReadwriteBuffer buffer;
+    unsigned char *ip = NULL, *line;
+
+    buffer.buffer = NULL;   /* BEFORE ANYTHING ELSE */
+
+    if (icsra == NULL) return IcsErr_NotValidAction;
+    if ( icsra->readOnly>0 && mode == IcsFileMode_write ) return IcsErr_FReadOnly;
+    if (im_stride == NULL) return IcsErr_IllParameter;
+    ics = &(icsra->ics);
+    ICSXJ( IcsGetLayout(ics, &dt, &dm, fl_dims) );
+    if ( dm != pdm ) {
+      error = IcsErr_DimensionalityMismatch;
+      goto ics_error;
+    }
+    ICSXJ( checkLimits( dm, fl_dims, fl_origin, rg_dims, fl_interval ));
+    if ( im_dims != NULL ) {
+        ICSXJ( checkLimits( dm, im_dims, im_origin, rg_dims, im_interval ));
+    }
+    elsize = IcsGetDataTypeSize( dt );
+    ICSXJ( initialiseBuffer( &buffer, dm, fl_dims, elsize,
+                             icsra->fp, ics->srcOffset, mode ));
+
+    computeStrides( dm, fl_dims, fl_stride );
+    f_offset = computeOffset( dm, fl_origin, fl_stride );
+    i_offset = computeOffset( dm, im_origin, im_stride );
+    /* switch to byte offsets and final strides (in bytes) */
+    f_offset *= elsize;
+    i_offset *= elsize;
+    computeFinalStrides( dm, elsize, fl_stride, fl_interval, f_stride );
+    computeFinalStrides( dm, elsize, im_stride, im_interval, i_stride );
+
+    for ( ii=0; ii<dm; ii++ ) {
+      r_dims[ii] = rg_dims[ii];
+      cors[ii] = 0;
+    }
+    optimiseProcessingOrder(dm,r_dims,f_stride,i_stride,&f_offset,&i_offset);
+
+    ip = (unsigned char *) image;
+    ip += i_offset;
+
+    boe = 0;
+    ci = 0;
+    line = buffer.buffer;
+    while(ci!=dm) {
+        for ( ii=0; ii<r_dims[0]; ii++ ) {
+            if ( f_offset >= boe ) {
+                ICSXJ(updateBuffer( &buffer, &f_offset, &boe));
+            }
+            if ( mode == IcsFileMode_write ) {
+                for ( jj=0; jj<elsize; jj++ ) {
+                    line[f_offset+icsra->bomap[jj]] = ip[jj];
+                }
+            } else {
+                for ( jj=0; jj<elsize; jj++ ) {
+                    ip[jj] = line[f_offset+icsra->bomap[jj]];
+                }
+            }
+            f_offset += f_stride[0];
+            ip += i_stride[0];
+        }
+        f_offset -= f_stride[0]*r_dims[0];
+        ip -= i_stride[0]*r_dims[0];
+        for ( ci=1; ci<dm; ci++ ) {
+            f_offset += f_stride[ci];
+            ip += i_stride[ci];
+            cors[ci]++;
+            if ( cors[ci] != r_dims[ci] ) break;
+            f_offset -= f_stride[ci]*r_dims[ci];
+            ip -= i_stride[ci]*r_dims[ci];
+            cors[ci]=0;
+        }
+    }
+    if ( mode == IcsFileMode_write ) {
+        ICSXJ( writeBuffer(&buffer));
+    }
+
+ics_error:
+    free(buffer.buffer);
+    return error;
+}
+
+Ics_Error Ics_RaCreate(const char         *filename,
+                       const char         *mode,
+                       const Ics_DataType  dt,
+                       const int           nbits,
+                       const int           dm,
+                       const size_t       *dims)
+{
+  ICSINIT;
+  unsigned char dummyByte = 0;
+  ICS ics;
+  size_t size;
+  FILE *fp = NULL;
+  int forceName = 0, forceLocale = 1;
+  int ii;
+
+  /* the mode string is "f" and/or "l" */
+  for (ii = 0; ii<strlen(mode); ii++) {
+      switch (mode[ii]) {
+          case 'f':
+              if (forceName) return IcsErr_IllParameter;
+              forceName = 1;
+              break;
+          case 'l':
+              if (forceLocale) return IcsErr_IllParameter;
+              forceLocale = 0;
+              break;
+          default:
+              return IcsErr_IllParameter;
+      }
+  }
+  IcsInit(&ics);
+  ics.fileMode = IcsFileMode_write;
+  ics.version = 2;
+  ICSXJ( IcsSetLayout( &ics, dt, dm, dims ));
+  ICSXJ( IcsSetSignificantBits ( &ics,  nbits));
+  ICSXJ( IcsSetCompression ( &ics, IcsCompr_uncompressed, 0 ));
+  ICSXJ( IcsWriteIcsLow( &ics, filename, &fp ));
+  size = IcsGetDataTypeSize( dt );
+  for ( ii=0; ii<dm; ii++ ) size *= dims[ii];
+
+  if (fseek( fp, size-1, SEEK_CUR )!=0 && !error) {
+     error = IcsErr_FWriteIds;
+     goto ics_error;
+  }
+  if (fwrite( &dummyByte, 1, 1, fp )!=1 && !error) {
+     error = IcsErr_FWriteIds;
+  }
+
+ics_error:
+  if (fp) {
+    fclose(fp);
+  }
+  return error;
+}

--- a/libics_random_access.h
+++ b/libics_random_access.h
@@ -1,0 +1,164 @@
+/*
+ * libics: Image Cytometry Standard file reading and writing.
+ *
+ * Copyright 2018:
+ *   Scientific Volume Imaging Holding B.V.
+ *   Laapersveld 63, 1213 VB Hilversum, The Netherlands
+ *   https://www.svi.nl
+ *
+ * Contact: libics@svi.nl
+ *
+ * Copyright (C) 2018 Michael van Ginkel
+ *
+ * Large chunks of this library written by
+ *    Bert Gijsbers
+ *    Dr. Hans T.M. van der Voort
+ * And also Damir Sudar, Geert van Kempen, Jan Jitze Krol,
+ * Chiel Baarslag and Fons Laan.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+ * FILE : libics_random_access.h
+ *
+ * Definitions for the random access (read/write ROIs) functions
+ *
+ * The random access functions can only be used on ICS files satisfying
+ * the following constraints:
+ * - single file (implies ICS v2)
+ * - uncompressed
+ *
+ * ROI = region of interest
+ * The general procedure is:
+ *   ICSRA *icsra;
+ *   # open existing ics file for reading and writing
+ *   Ics_RaOpen( &icsra, filename, mode );
+ *   # one or more calls to Ics_RaReadOrWrite reading/writing
+ *   # ROIs in the on-disk image from/into a ROI of an in memory image
+ *   Ics_RaClose( icsra );   # closes the file
+ */
+
+#ifndef LIBICS_RANDOM_ACCESS_H
+#define LIBICS_RANDOM_ACCESS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include "libics.h"
+
+
+
+/* Structures that define the image representation. They are only used inside
+   the ICS data structure. */
+typedef struct {
+  ICS   ics;
+  FILE *fp;
+  int   bomap[ICS_MAX_IMEL_SIZE];   /* byte order mapping */
+  int   readOnly;
+} ICSRA;
+
+/* Open an existing ics file (must be uncompressed v2) for random read/write
+ * access. The ICSRA structure that is returned is a handle that allows the
+ * other random access functions to keep track of the file. Note that this
+ * is different from the ICS structure that is used throughout the remainder
+ * of libics. The <mode> parameter is similar to that of IcsOpen() however
+ * using different modes:
+ *   "ro" for read-only access
+ *   "rw" for read-write access (the default, i.e. "" is interpreted as "rw")
+ * this can be affixed with "f" and/or "l" with the same meaning as they
+ * have in IcsOpen. Note that read-write access applies to the image data
+ * in the ICS file; the header remains untouched.
+ */
+ICSEXPORT Ics_Error Ics_RaOpen(ICSRA      **icsra,
+                               const char  *filename,
+                               const char  *mode);
+/* Closes the ics file */
+ICSEXPORT Ics_Error Ics_RaClose(ICSRA      *icsra);
+/* Read or write into an ics file opened with Ics_RaOpen(). A region of
+ * interest can be specified for either of both the ics file and the in-memory
+ * image. The parameters are:
+ *
+ *   ICSRA *icsra
+ *   int        dm           included as a sanity check. The dimensionality of
+ *                           the in-memory image. Must equal the dimensionality
+ *                           of the ICS image data
+ * 0 size_t    *rg_dims      dimensions of the regions to be copied.
+ *                           NULL: use dimensions of ics file
+ * 0 size_t    *fl_origin    origin of the ROI within the ics
+ * 0 ptrdiff_t *fl_interval  step size to be made between pixels in the ics file
+ *   void      *image        image data
+ * 0 size_t    *im_dims      sanity check. If provided is used to check
+ *                           im_origin and im_interval
+ *   size_t    *im_stride    step size to be made in memory to move to the
+ *                           next pixel (describes the image layout)
+ * 0 size_t    *im_origin    origin of the ROI within the image
+ * 0 ptrdiff_t *im_interval  step size to be made between pixels
+ *   Ics_FileMode mode       allowed are:
+ *                              IcsFileMode_read  : move data ICS -> image
+ *                              IcsFileMode_write : move data image -> ICS
+ *
+ * Any parameter with a "0" in front can be set to NULL
+ *
+ * Note on stride and interval parameters: N-D image data is stored in a
+ * 1D array. Usually, but not necessarily, I(x,y) and I(x+1,y) are stored
+ * next to each other in this 1D array. As a consequence I(x,y) and I(x,y+1)
+ * can lie next to each other. They are e.g. stored Sy elements apart. This
+ * is the <stride> for dimension y. The stride array describes the layout
+ * of an image in memory (or in the file). The code knows the layout of
+ * the ics file, hence no fl_stride parameter is present. The im_stride
+ * parameter is obligatory. The strides are given in pixels, not bytes.
+ *   The interval parameters allows you to skip pixels (downsample) while
+ * copying (both at the source and at the destination). If we consider
+ * e.g. fl_interval=[3,1] then every third pixel is read along the x-axis:
+ * the step size in the underlying 1D array becomes stride*interval. The
+ * interval values are allowed to be negative.
+ * 
+ * For clarity: the rg_dims parameter gives the amount of pixels to be copied
+ * along each dimension. When using intervals, this means the source or
+ * destination region covers rg_dims*abs(interval) pixels
+ */
+ICSEXPORT Ics_Error Ics_RaReadOrWrite(const ICSRA        *icsra,
+                                      const int           dm,
+                                      const size_t       *rg_dims,
+                                      const size_t       *fl_origin,
+                                      const ptrdiff_t    *fl_interval,
+                                      const void         *image,
+                                      const size_t       *im_dims,
+                                      const size_t       *im_stride,
+                                      const size_t       *im_origin,
+                                      const ptrdiff_t    *im_interval,
+                                      const Ics_FileMode  mode);
+/* Create an ics file with the given name, data type and dimensions. It can
+ * then be opened with Ics_RaOpen and accessed with Ics_RaReadOrWrite.
+ * The file is created by writing a single byte at the last position. I cannot
+ * find a definite statement on whether the intervening data is zeroed by
+ * the operating system/POSIX standard. Best not to depend on that! The mode
+ * parameter is identical to Ics_RaOpen's mode parameter
+ */
+ICSEXPORT Ics_Error Ics_RaCreate(const char         *filename,
+                                 const char         *mode,
+                                 const Ics_DataType  dt,
+                                 const int           significantBits,
+                                 const int           dm,
+                                 const size_t       *dims);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libics_top.c
+++ b/libics_top.c
@@ -1295,6 +1295,21 @@ const char *IcsGetErrorText(Ics_Error error)
             msg = "libics is linking to a different version of zlib than used "
                 "during compilation";
             break;
+        case IcsErr_FReadOnly:
+            msg = "Attempting to write in read-only mode";
+            break;
+        case IcsErr_DimensionalityMismatch:
+            msg = "Mismatch between dimensionality of ICS file and parameter";
+            break;
+        case IcsErr_Version2Required:
+            msg = "Random access requires an ICS v2 file";
+            break;
+        case IcsErr_RaSingleFileRequired:
+            msg = "Random access requires a single ics file";
+            break;
+        case IcsErr_RaOnlyUncompressedDataSupported:
+            msg = "Random access requires uncompressed ics";
+            break;
         default:
             msg = "Some error occurred I know nothing about.";
     }

--- a/libics_util.c
+++ b/libics_util.c
@@ -301,14 +301,15 @@ char *IcsGetIdsName(char       *dest,
 /* Open an .ics file, even if the name given end in .ids. */
 Ics_Error IcsOpenIcs(FILE **fpp,
                      char  *filename,
-                     int    forceName)
+                     int    forceName,
+                     char  *mode)
 {
     ICSINIT;
     FILE* fp;
     char FileName[ICS_MAXPATHLEN];
 
     IcsGetIcsName(FileName, filename, forceName);
-    fp = IcsFOpen(FileName, "rb");
+    fp = IcsFOpen(FileName, mode);
     if (fp == NULL) return IcsErr_FOpenIcs;
 
     *fpp = fp;

--- a/libics_write.c
+++ b/libics_write.c
@@ -946,6 +946,19 @@ static Ics_Error markEndOfFile(Ics_Header *icsStruct,
 Ics_Error IcsWriteIcs(Ics_Header *icsStruct,
                       const char *filename)
 {
+  return IcsWriteIcsLow(icsStruct,filename,NULL);
+}
+
+/*
+ * The Ics_RaCreate function requires
+ * - the FILE descriptor to be returned
+ * hence the introduction of the <fpret> parameter. In ALL other use cases
+ * it must be NULL
+ */
+Ics_Error IcsWriteIcsLow(Ics_Header *icsStruct,
+                         const char *filename,
+                         FILE       **fpret)
+{
     ICSINIT;
     ICS_INIT_LOCALE;
     char  line[ICS_LINE_LENGTH];
@@ -1003,9 +1016,13 @@ Ics_Error IcsWriteIcs(Ics_Header *icsStruct,
 
     ICS_REVERT_LOCALE;
 
-    if (fclose(fp) == EOF) {
-        if (!error) error = IcsErr_FCloseIcs; /* Don't overwrite any previous
-                                                 error. */
+    if (fpret && !error) {
+        *fpret = fp;
+    } else {
+        if (fclose(fp) == EOF) {
+            if (!error) error = IcsErr_FCloseIcs; /* Don't overwrite any previous
+                                                     error. */
+        }
     }
     return error;
 }


### PR DESCRIPTION
Initial version of the following functions:

- Ics_RaOpen
- Ics_RaReadOrWrite
- Ics_RaClose
- Ics_RaCreate

The first three allow you to read and write ROIs to uncompressed, single file,
ICS v2 files. The last allows you to create an empty ICS file with given
datatype and dimensions - useful when you are processing large files and
need to create the output file or a scratch file.

Some existing functions needed to be modified in order to be able to open
the ICS file in the correct mode and obtain the FILE handle: contrary to
the existing library functions the ICS file is kept open until Ics_RaClose()
is called. Affected are:

- IcsOpenIcs
- IcsReadIcs
- IcsWriteIcs