### PR TITLE
Fixes for building without ZLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@
 #   Heavily modified by Cris Luengo, July 2017
 #
 ##############################################################################
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
+if(POLICY CMP0068)
+    cmake_policy(SET CMP0068 NEW)
+endif()
 
 project(libics VERSION 1.6.2)
 
@@ -27,7 +30,7 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED on)
 
 if (CMAKE_C_COMPILER_ID MATCHES "Clang") # also matchs "AppleClang"
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wall -Wconversion -Wsign-conversion")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion")
 elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -Wno-unused-parameter")
 elseif (CMAKE_C_COMPILER_ID STREQUAL "Intel")
@@ -84,6 +87,7 @@ target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # For Windows, when 
 target_include_directories(libics PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 if (UNIX)
     set_target_properties(libics PROPERTIES OUTPUT_NAME "ics")
+    target_link_libraries(libics PUBLIC m)
 endif (UNIX)
 
 # Build a static library
@@ -91,18 +95,20 @@ add_library(libics_static STATIC ${SOURCES} ${HEADERS})
 target_include_directories(libics_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 if (UNIX)
     set_target_properties(libics_static PROPERTIES OUTPUT_NAME "ics")
+    target_link_libraries(libics PUBLIC m)
 endif (UNIX)
 
 # Link against zlib
 if(LIBICS_USE_ZLIB)
     target_link_libraries(libics PUBLIC ${ZLIB_LIBRARIES})
     target_include_directories(libics PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_compile_definitions(libics PRIVATE -DICS_ZLIB)
+    target_compile_definitions(libics PUBLIC -DICS_ZLIB)
     target_link_libraries(libics_static PUBLIC ${ZLIB_LIBRARIES})
     target_include_directories(libics_static PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_compile_definitions(libics_static PRIVATE -DICS_ZLIB)
+    target_compile_definitions(libics_static PUBLIC -DICS_ZLIB)
 endif()
 
+# Reentrant string tokenization
 if (HAVE_STRTOK_R)
   target_compile_definitions(libics PRIVATE -DHAVE_STRTOK_R)
   target_compile_definitions(libics_static PRIVATE -DHAVE_STRTOK_R)
@@ -120,8 +126,10 @@ add_executable(test_ics2a EXCLUDE_FROM_ALL test_ics2a.c)
 target_link_libraries(test_ics2a libics)
 add_executable(test_ics2b EXCLUDE_FROM_ALL test_ics2b.c)
 target_link_libraries(test_ics2b libics)
-add_executable(test_gzip EXCLUDE_FROM_ALL test_gzip.c)
-target_link_libraries(test_gzip libics)
+if(LIBICS_USE_ZLIB)
+    add_executable(test_gzip EXCLUDE_FROM_ALL test_gzip.c)
+    target_link_libraries(test_gzip libics)
+endif()
 add_executable(test_compress EXCLUDE_FROM_ALL test_compress.c)
 target_link_libraries(test_compress libics)
 add_executable(test_strides EXCLUDE_FROM_ALL test_strides.c)
@@ -134,11 +142,10 @@ add_executable(test_metadata EXCLUDE_FROM_ALL test_metadata.c)
 target_link_libraries(test_metadata libics)
 add_executable(test_history EXCLUDE_FROM_ALL test_history.c)
 target_link_libraries(test_history libics)
-add_custom_target(all_tests DEPENDS
+set(TEST_PROGRAMS
       test_ics1
       test_ics2a
       test_ics2b
-      test_gzip
       test_compress
       test_strides
       test_strides2
@@ -146,6 +153,10 @@ add_custom_target(all_tests DEPENDS
       test_metadata
       test_history
       )
+if(LIBICS_USE_ZLIB)
+   set(TEST_PROGRAMS ${TEST_PROGRAMS} test_gzip)
+endif()
+add_custom_target(all_tests DEPENDS ${TEST_PROGRAMS})
 add_test(ctest_build_test_code "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target all_tests)
 add_test(NAME test_ics1 COMMAND test_ics1 "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v1.ics)
 set_tests_properties(test_ics1 PROPERTIES DEPENDS ctest_build_test_code)
@@ -153,8 +164,10 @@ add_test(NAME test_ics2a COMMAND test_ics2a "${CMAKE_CURRENT_SOURCE_DIR}/test/te
 set_tests_properties(test_ics2a PROPERTIES DEPENDS ctest_build_test_code)
 add_test(NAME test_ics2b COMMAND test_ics2b "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2b.ics)
 set_tests_properties(test_ics2b PROPERTIES DEPENDS ctest_build_test_code)
-add_test(NAME test_gzip COMMAND test_gzip "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2z.ics)
-set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
+if(LIBICS_USE_ZLIB)
+    add_test(NAME test_gzip COMMAND test_gzip "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2z.ics)
+    set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
+endif()
 add_test(NAME test_compress COMMAND test_compress "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" "${CMAKE_CURRENT_SOURCE_DIR}/test/testim_c.ics")
 set_tests_properties(test_compress PROPERTIES DEPENDS ctest_build_test_code)
 add_test(NAME test_strides COMMAND test_strides "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_s.ics)
@@ -169,7 +182,9 @@ add_test(NAME test_metadata2 COMMAND test_metadata result_v2a.ics)
 set_tests_properties(test_metadata2 PROPERTIES DEPENDS test_ics2a)
 add_test(NAME test_metadata3 COMMAND test_metadata result_v2b.ics)
 set_tests_properties(test_metadata3 PROPERTIES DEPENDS test_ics2b)
-add_test(NAME test_metadata4 COMMAND test_metadata result_v2z.ics)
-set_tests_properties(test_metadata4 PROPERTIES DEPENDS test_gzip)
+if(LIBICS_USE_ZLIB)
+    add_test(NAME test_metadata4 COMMAND test_metadata result_v2z.ics)
+    set_tests_properties(test_metadata4 PROPERTIES DEPENDS test_gzip)
+endif()
 add_test(NAME test_history COMMAND test_history result_v1.ics)
 set_tests_properties(test_history PROPERTIES DEPENDS test_ics1)

--- a/README
+++ b/README
@@ -41,6 +41,7 @@ libics@svi.nl
 
    Documentation
 ==============================
+
    Online documentation can be found at: https://svi-opensource.github.io/libics
 
    Installation Instructions
@@ -100,7 +101,6 @@ libics.dll.lib. To make a debug version add '/D DEBUG' to these
 commands. To disable zlib support, remove the definition of ZLIB_SUPPORT
 from the file Makefile.vc.
 
-
  - Compilation with CMake under UNIX / Linux / Mac OS X / Cygwin
 
 Run the following commands from outside the source directory
@@ -143,7 +143,7 @@ This library was originally written and maintained by
    Centre for Image Analysis
    Swedish University of Agricultural Sciences & Uppsala University
    Uppsala, Sweden
-   
+
 With help from
    Bert Gijsbers, Scientific Volume Imaging BV, Hilversum, NL
       (Most changes for version 1.3)
@@ -169,7 +169,7 @@ Most of the code herein hasn't changed since the previous version, by
 Which ultimately is based upon stuff written by:
    Damir Sudar, Geert van Kempen, Jan Jitze Krol,
    Chiel Baarslag, Fons Laan and Hans van der Voort.
-   
+
 
    HISTORY
 =============

--- a/libics_binary.c
+++ b/libics_binary.c
@@ -58,11 +58,6 @@
 #include "libics_intern.h"
 
 
-#if defined(ICS_DO_GZEXT) && !defined(ICS_ZLIB)
-#undef ICS_DO_GZEXT
-#endif
-
-
 /* Write uncompressed data, with strides. */
 Ics_Error IcsWritePlainWithStrides(const void      *src,
                                    const size_t    *dim,

--- a/libics_gzip.c
+++ b/libics_gzip.c
@@ -60,14 +60,16 @@
 #include <string.h>
 #include "libics_intern.h"
 
-
-#include "zlib.h"
-
+// Include zlib.h only when available
+#ifdef ICS_ZLIB
+    #include "zlib.h"
+#endif
 
 #define DEF_MEM_LEVEL 8 /* Default value defined in zutil.h */
 
 
 /* GZIP stuff */
+#ifdef ICS_ZLIB
 #ifdef WIN32
 #define OS_CODE 0x0b
 #else
@@ -81,9 +83,10 @@ static int gz_magic[2] = {0x1f, 0x8b}; /* gzip magic header */
 #define ORIG_NAME    0x08 /* bit 3 set: original file name present */
 #define COMMENT      0x10 /* bit 4 set: file comment present */
 #define RESERVED     0xE0 /* bits 5..7: reserved */
-
+#endif // ICS_ZLIB
 
 /* Outputs a long in LSB order to the given stream */
+#ifdef ICS_ZLIB
 static void icsPutLong(FILE *file,
                        unsigned long int x)
 {
@@ -93,9 +96,11 @@ static void icsPutLong(FILE *file,
       x >>= 8;
    }
 }
+#endif
 
 
 /* Reads a long in LSB order from the given stream. */
+#ifdef ICS_ZLIB
 static unsigned long int icsGetLong(FILE *file)
 {
     unsigned long int x = (unsigned long int)getc(file);
@@ -104,6 +109,7 @@ static unsigned long int icsGetLong(FILE *file)
     x += ((unsigned long int)getc(file))<<24;
     return x;
 }
+#endif
 
 
 /* Write ZIP compressed data. This function mostly does:
@@ -201,6 +207,10 @@ Ics_Error IcsWriteZip(const void *inBuf,
 
     return err == Z_OK ? IcsErr_Ok : IcsErr_CompressionProblem;
 #else
+    (void)inBuf;
+    (void)len;
+    (void)file;
+    (void)level;
     return IcsErr_UnknownCompression;
 #endif
 }
@@ -365,6 +375,13 @@ Ics_Error IcsWriteZipWithStrides(const void      *src,
         return err == Z_OK ? IcsErr_Ok : IcsErr_CompressionProblem;
     }
 #else
+    (void)src;
+    (void)dim;
+    (void)stride;
+    (void)nDims;
+    (void)nBytes;
+    (void)file;
+    (void)level;
     return IcsErr_UnknownCompression;
 #endif
 }
@@ -449,6 +466,7 @@ Ics_Error IcsOpenZip(Ics_Header *icsStruct)
     br->zlibCRC = crc32(0L, Z_NULL, 0);
     return IcsErr_Ok;
 #else
+    (void)icsStruct;
     return IcsErr_UnknownCompression;
 #endif
 }
@@ -474,6 +492,7 @@ Ics_Error IcsCloseZip(Ics_Header *icsStruct)
     }
     return IcsErr_Ok;
 #else
+    (void)icsStruct;
     return IcsErr_UnknownCompression;
 #endif
 }
@@ -482,8 +501,8 @@ Ics_Error IcsCloseZip(Ics_Header *icsStruct)
 /* Read ZIP compressed data block. This function mostly does:
      gzread((gzFile)br->ZlibStream, outBuf, len); */
 Ics_Error IcsReadZipBlock(Ics_Header *icsStruct,
-                           void       *outBuf,
-                           size_t      len)
+                          void       *outBuf,
+                          size_t      len)
 {
 #ifdef ICS_ZLIB
     Ics_BlockRead *br      = (Ics_BlockRead*)icsStruct->blockRead;
@@ -548,6 +567,9 @@ Ics_Error IcsReadZipBlock(Ics_Header *icsStruct,
     if (err == Z_OK) return IcsErr_Ok;
     return IcsErr_DecompressionProblem;
 #else
+    (void)icsStruct;
+    (void)outBuf;
+    (void)len;
     return IcsErr_UnknownCompression;
 #endif
 }
@@ -556,8 +578,8 @@ Ics_Error IcsReadZipBlock(Ics_Header *icsStruct,
 /* Skip ZIP compressed data block. This function mostly does:
      gzseek((gzFile)br->ZlibStream, (z_off_t)offset, whence); */
 Ics_Error IcsSetZipBlock(Ics_Header *icsStruct,
-                          long        offset,
-                          int         whence)
+                         long        offset,
+                         int         whence)
 {
 #ifdef ICS_ZLIB
     ICSINIT;
@@ -601,6 +623,9 @@ Ics_Error IcsSetZipBlock(Ics_Header *icsStruct,
 
     return error;
 #else
+    (void)icsStruct;
+    (void)offset;
+    (void)whence;
     return IcsErr_UnknownCompression;
 #endif
 }

--- a/libics_top.c
+++ b/libics_top.c
@@ -550,7 +550,7 @@ Ics_Error IcsGetDataWithStrides(ICS             *ics,
     char            *buf;
     char            *dest = (char*)destPtr;
     char            *out;
-
+    (void)n; /* we're not using this parameter */
 
     if ((ics == NULL) || (ics->fileMode == IcsFileMode_write))
         return IcsErr_NotValidAction;

--- a/test_compress.c
+++ b/test_compress.c
@@ -49,7 +49,7 @@ int main (int argc, const char* argv[]) {
    /* Read image 2 */
    retval = IcsOpen(&ip, argv[2], "r");
    if (retval != IcsErr_Ok) {
-      fprintf(stderr, "Could not open output file for reading: %s\n",
+      fprintf(stderr, "Could not open compressed file for reading: %s\n",
                IcsGetErrorText(retval));
       exit(-1);
    }
@@ -69,7 +69,7 @@ int main (int argc, const char* argv[]) {
    }
    retval = IcsGetData(ip, buf2, bufsize);
    if (retval != IcsErr_Ok) {
-      fprintf(stderr, "Could not read output image data: %s\n",
+      fprintf(stderr, "Could not read compressed image data: %s\n",
                IcsGetErrorText(retval));
       exit(-1);
    }

--- a/test_strides.c
+++ b/test_strides.c
@@ -71,7 +71,9 @@ int main(int argc, const char* argv[]) {
    }
    IcsSetLayout(ip, dt, ndims, dims);
    IcsSetDataWithStrides(ip, buf3, bufsize, strides, 3);
+#ifdef ICS_ZLIB
    IcsSetCompression(ip, IcsCompr_gzip, 6);
+#endif
    retval = IcsClose(ip);
    if (retval != IcsErr_Ok) {
       fprintf(stderr, "Could not write output file: %s\n",

--- a/test_strides2.c
+++ b/test_strides2.c
@@ -71,7 +71,9 @@ int main(int argc, const char* argv[]) {
    }
    IcsSetLayout(ip, dt, ndims, dims);
    IcsSetDataWithStrides(ip, buf3, 2*bufsize, strides, 3);
+#ifdef ICS_ZLIB
    IcsSetCompression(ip, IcsCompr_gzip, 6);
+#endif
    retval = IcsClose(ip);
    if (retval != IcsErr_Ok) {
       fprintf(stderr, "Could not write output file: %s\n",

--- a/test_strides3.c
+++ b/test_strides3.c
@@ -73,7 +73,9 @@ int main(int argc, const char* argv[]) {
    }
    IcsSetLayout(ip, dt, ndims, dims);
    IcsSetDataWithStrides(ip, buf3 + bufsize - imelsize, bufsize, strides, 3);
+#ifdef ICS_ZLIB
    IcsSetCompression(ip, IcsCompr_gzip, 6);
+#endif
    retval = IcsClose(ip);
    if (retval != IcsErr_Ok) {
       fprintf(stderr, "Could not write output file: %s\n",


### PR DESCRIPTION
If `LIBICS_USE_ZLIB` CMake variable is not defined, the two tests specific to compression are not run. It might be necessary to add a similar fix to the `configure` script.

Within the sources, if `ICS_ZLIB` is not defined, three tests don't try to enable compression, `"zlib.h"` is not included, and input variables are "touched" to prevent compiler warnings.

`IcsGetDataWithStrides` has an unused parameter which was generating a compiler warning, it is "touched" now as well.

I've also added and removed a few spaces here and there for consistency.