### PR TITLE
A C++ interface, plus a few improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ libtool
 Makefile
 stamp-*
 stamp-h2
-
+target*
 
 # aclocal.m4
 # autom4te.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##############################################################################
 cmake_minimum_required(VERSION 3.5)
 if(POLICY CMP0068)
-    cmake_policy(SET CMP0068 NEW)
+   cmake_policy(SET CMP0068 NEW)
 endif()
 
 project(libics VERSION 1.6.2)
@@ -29,30 +29,20 @@ project(libics VERSION 1.6.2)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED on)
 
-if (CMAKE_C_COMPILER_ID MATCHES "Clang") # also matchs "AppleClang"
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion")
-elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -Wno-unused-parameter")
-elseif (CMAKE_C_COMPILER_ID STREQUAL "Intel")
-    # TODO: compiler flags for Intel compiler
-elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-    # TODO: compiler flags for MSVC compiler
+if(CMAKE_C_COMPILER_ID MATCHES "Clang") # also matchs "AppleClang"
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -pedantic")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -Wno-unused-parameter -pedantic")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+   # TODO: compiler flags for Intel compiler
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+   # TODO: compiler flags for MSVC compiler
 endif()
 
 # Debug or Release?
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
+   set(CMAKE_BUILD_TYPE Release)
 endif()
-
-# Zlib
-find_package(ZLIB)
-if(ZLIB_FOUND)
-    set(LIBICS_USE_ZLIB TRUE CACHE BOOL "Use Zlib in libics")
-endif()
-
-# Reentrant string tokenization
-include(CheckFunctionExists)
-check_function_exists(strtok_r HAVE_STRTOK_R)
 
 # ICS
 configure_file(libics_conf.h.in ${CMAKE_CURRENT_SOURCE_DIR}/libics_conf.h COPYONLY)
@@ -82,30 +72,34 @@ set(HEADERS
 
 add_library(libics ${SOURCES} ${HEADERS})
 
-if (BUILD_SHARED_LIBS)
-    target_compile_definitions(libics PRIVATE BUILD_ICSLIB) # For Windows, when compiling DLL
-    target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # For Windows, when linking against DLL
-endif ()
+if(BUILD_SHARED_LIBS)
+   target_compile_definitions(libics PRIVATE BUILD_ICSLIB) # When compiling DLL/SO
+   target_compile_definitions(libics INTERFACE USE_ICSLIB_DLL) # When linking against DLL/SO
+endif()
 
-target_include_directories(libics PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-)
+target_include_directories(libics PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
-if (UNIX)
-    set_target_properties(libics PROPERTIES OUTPUT_NAME "ics")
-    target_link_libraries(libics PUBLIC m)
-endif (UNIX)
+if(UNIX)
+   set_target_properties(libics PROPERTIES OUTPUT_NAME "ics")
+   target_link_libraries(libics PUBLIC m)
+endif(UNIX)
 
 # Link against zlib
+find_package(ZLIB)
+if(ZLIB_FOUND)
+   set(LIBICS_USE_ZLIB TRUE CACHE BOOL "Use Zlib in libics")
+endif()
 if(LIBICS_USE_ZLIB)
-    target_link_libraries(libics PUBLIC ${ZLIB_LIBRARIES})
-    target_include_directories(libics PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_compile_definitions(libics PUBLIC -DICS_ZLIB)
+   target_link_libraries(libics PUBLIC ${ZLIB_LIBRARIES})
+   target_include_directories(libics PRIVATE ${ZLIB_INCLUDE_DIRS})
+   target_compile_definitions(libics PUBLIC -DICS_ZLIB)
 endif()
 
 # Reentrant string tokenization
-if (HAVE_STRTOK_R)
-  target_compile_definitions(libics PRIVATE -DHAVE_STRTOK_R)
+include(CheckFunctionExists)
+check_function_exists(strtok_r HAVE_STRTOK_R)
+if(HAVE_STRTOK_R)
+   target_compile_definitions(libics PRIVATE -DHAVE_STRTOK_R)
 endif()
 
 # Install
@@ -113,34 +107,35 @@ export(TARGETS libics FILE cmake/libicsTargets.cmake)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    cmake/libicsConfigVersion.cmake
-    VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY AnyNewerVersion)
+      cmake/libicsConfigVersion.cmake
+      VERSION ${PACKAGE_VERSION}
+      COMPATIBILITY AnyNewerVersion)
 
 configure_package_config_file(
-    cmake/libicsConfig.cmake.in
-    cmake/libicsConfig.cmake
-    INSTALL_DESTINATION cmake/)
+      cmake/libicsConfig.cmake.in
+      cmake/libicsConfig.cmake
+      INSTALL_DESTINATION cmake/)
 
 install(TARGETS libics
-    EXPORT libicsTargets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include)
+      EXPORT libicsTargets
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+      INCLUDES DESTINATION include)
 
 install(FILES ${HEADERS} DESTINATION include)
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/libicsConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/libicsConfigVersion.cmake
-    DESTINATION cmake/)
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/libicsConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/libicsConfigVersion.cmake
+      DESTINATION cmake/)
 
 install(EXPORT libicsTargets DESTINATION cmake)
 
 
 # Unit tests
 enable_testing()
+
 add_executable(test_ics1 EXCLUDE_FROM_ALL test_ics1.c)
 target_link_libraries(test_ics1 libics)
 add_executable(test_ics2a EXCLUDE_FROM_ALL test_ics2a.c)
@@ -148,8 +143,8 @@ target_link_libraries(test_ics2a libics)
 add_executable(test_ics2b EXCLUDE_FROM_ALL test_ics2b.c)
 target_link_libraries(test_ics2b libics)
 if(LIBICS_USE_ZLIB)
-    add_executable(test_gzip EXCLUDE_FROM_ALL test_gzip.c)
-    target_link_libraries(test_gzip libics)
+   add_executable(test_gzip EXCLUDE_FROM_ALL test_gzip.c)
+   target_link_libraries(test_gzip libics)
 endif()
 add_executable(test_compress EXCLUDE_FROM_ALL test_compress.c)
 target_link_libraries(test_compress libics)
@@ -163,6 +158,7 @@ add_executable(test_metadata EXCLUDE_FROM_ALL test_metadata.c)
 target_link_libraries(test_metadata libics)
 add_executable(test_history EXCLUDE_FROM_ALL test_history.c)
 target_link_libraries(test_history libics)
+
 set(TEST_PROGRAMS
       test_ics1
       test_ics2a
@@ -178,6 +174,7 @@ if(LIBICS_USE_ZLIB)
    set(TEST_PROGRAMS ${TEST_PROGRAMS} test_gzip)
 endif()
 add_custom_target(all_tests DEPENDS ${TEST_PROGRAMS})
+
 add_test(ctest_build_test_code "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target all_tests)
 add_test(NAME test_ics1 COMMAND test_ics1 "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v1.ics)
 set_tests_properties(test_ics1 PROPERTIES DEPENDS ctest_build_test_code)
@@ -186,8 +183,8 @@ set_tests_properties(test_ics2a PROPERTIES DEPENDS ctest_build_test_code)
 add_test(NAME test_ics2b COMMAND test_ics2b "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2b.ics)
 set_tests_properties(test_ics2b PROPERTIES DEPENDS ctest_build_test_code)
 if(LIBICS_USE_ZLIB)
-    add_test(NAME test_gzip COMMAND test_gzip "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2z.ics)
-    set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
+   add_test(NAME test_gzip COMMAND test_gzip "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2z.ics)
+   set_tests_properties(test_gzip PROPERTIES DEPENDS ctest_build_test_code)
 endif()
 add_test(NAME test_compress COMMAND test_compress "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" "${CMAKE_CURRENT_SOURCE_DIR}/test/testim_c.ics")
 set_tests_properties(test_compress PROPERTIES DEPENDS ctest_build_test_code)
@@ -204,8 +201,15 @@ set_tests_properties(test_metadata2 PROPERTIES DEPENDS test_ics2a)
 add_test(NAME test_metadata3 COMMAND test_metadata result_v2b.ics)
 set_tests_properties(test_metadata3 PROPERTIES DEPENDS test_ics2b)
 if(LIBICS_USE_ZLIB)
-    add_test(NAME test_metadata4 COMMAND test_metadata result_v2z.ics)
-    set_tests_properties(test_metadata4 PROPERTIES DEPENDS test_gzip)
+   add_test(NAME test_metadata4 COMMAND test_metadata result_v2z.ics)
+   set_tests_properties(test_metadata4 PROPERTIES DEPENDS test_gzip)
 endif()
 add_test(NAME test_history COMMAND test_history result_v1.ics)
 set_tests_properties(test_history PROPERTIES DEPENDS test_ics1)
+
+
+# Include the C++ interface?
+set(LIBICS_INCLUDE_CPP TRUE CACHE BOOL "Include the C++ interface")
+if(LIBICS_INCLUDE_CPP)
+   include(support/cpp_interface/CMakeLists.txt)
+endif()

--- a/README
+++ b/README
@@ -112,15 +112,15 @@ The library can be tested for problems using
    make test
 
 CMake can be used with the following options:
-   cmake ... -DCMAKE_BUILD_TYPE=Debug
-   cmake ... -DLIBICS_USE_ZLIB=Off
+   cmake ... -DCMAKE_BUILD_TYPE=Debug # build a debug version
+   cmake ... -DLIBICS_USE_ZLIB=Off    # do not use zlib
+   cmake ... -DBUILD_SHARED_LIBS=On   # build a shared library
+   cmake ... -DLIBICS_INCLUDE_CPP=Off # do not include the C++ interface
 
 CMake projects using libics as a subproject can do
    add_subdirectory(<path/to/libics/sources>)
    target_link_libraries(target PRIVATE libics)
-or
-   target_link_libraries(target PRIVATE libics_static)
-The include directory for libics will be automatically set, and the ZLib
+The include directory for libics will be automatically set, and the zlib
 library will be linked if necessary.
 
  - Compilation with cmake on Windows:

--- a/libics.h
+++ b/libics.h
@@ -480,7 +480,7 @@ typedef enum {
 } Ics_HistoryWhich;
 
 
-typedef struct {
+typedef struct _Ics_HistoryIterator {
     int  next;                    /* index into history array, pointing to next
                                      string to read, set to -1 if there's no
                                      more to read. */

--- a/support/cpp_interface/CMakeLists.txt
+++ b/support/cpp_interface/CMakeLists.txt
@@ -1,0 +1,102 @@
+##############################################################################
+#
+# libics: Image Cytometry Standard file reading and writing.
+#
+# C++ interface
+# Copyright 2018 Cris Luengo
+#
+##############################################################################
+
+# Compiler flags
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # also matchs "AppleClang"
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wconversion -Wsign-conversion -pedantic")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wconversion -Wsign-conversion -pedantic")
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+   # TODO: compiler flags for Intel compiler
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+   # TODO: compiler flags for MSVC compiler
+endif()
+
+set(SOURCES ${CMAKE_CURRENT_LIST_DIR}/libics.cpp)
+set(HEADERS ${CMAKE_CURRENT_LIST_DIR}/libics.hpp)
+
+add_library(libics_cpp ${SOURCES} ${HEADERS})
+target_link_libraries(libics_cpp PRIVATE libics)
+
+if(BUILD_SHARED_LIBS)
+   target_compile_definitions(libics_cpp PRIVATE BUILD_ICSCPP) # When compiling DLL/SO
+   target_compile_definitions(libics_cpp INTERFACE USE_ICSCPP_DLL) # When linking against DLL/SO
+endif()
+
+target_include_directories(libics_cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+if(UNIX)
+   set_target_properties(libics_cpp PROPERTIES OUTPUT_NAME "ics_cpp")
+endif(UNIX)
+
+# Install
+export(TARGETS libics_cpp FILE cmake/libics_cppTargets.cmake)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+      cmake/libics_cppConfigVersion.cmake
+      VERSION ${PACKAGE_VERSION}
+      COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libicsConfig.cmake.in
+      cmake/libics_cppConfig.cmake
+      INSTALL_DESTINATION cmake/)
+
+install(TARGETS libics_cpp
+      EXPORT libics_cppTargets
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+      INCLUDES DESTINATION include)
+
+install(FILES ${HEADERS} DESTINATION include)
+
+install(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/libics_cppConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/libics_cppConfigVersion.cmake
+      DESTINATION cmake/)
+
+install(EXPORT libics_cppTargets DESTINATION cmake)
+
+
+# Unit tests
+add_executable(test_ics2a_cpp EXCLUDE_FROM_ALL ${CMAKE_CURRENT_LIST_DIR}/test_ics2a.cpp)
+target_link_libraries(test_ics2a_cpp libics_cpp)
+add_executable(test_ics2b_cpp EXCLUDE_FROM_ALL ${CMAKE_CURRENT_LIST_DIR}/test_ics2b.cpp)
+target_link_libraries(test_ics2b_cpp libics_cpp)
+add_executable(test_metadata_cpp EXCLUDE_FROM_ALL ${CMAKE_CURRENT_LIST_DIR}/test_metadata.cpp)
+target_link_libraries(test_metadata_cpp libics_cpp)
+add_executable(test_history_cpp EXCLUDE_FROM_ALL ${CMAKE_CURRENT_LIST_DIR}/test_history.cpp)
+target_link_libraries(test_history_cpp libics_cpp)
+
+set(TEST_PROGRAMS ${TEST_PROGRAMS} test_ics2a_cpp test_ics2b_cpp test_metadata_cpp test_history_cpp)
+add_dependencies(all_tests ${TEST_PROGRAMS})
+
+add_test(NAME test_ics2a_cpp COMMAND test_ics2a_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2a_cpp.ics)
+set_tests_properties(test_ics2a_cpp PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_ics2b_cpp COMMAND test_ics2b_cpp "${CMAKE_CURRENT_SOURCE_DIR}/test/testim.ics" result_v2b_cpp.ics)
+set_tests_properties(test_ics2b_cpp PROPERTIES DEPENDS ctest_build_test_code)
+add_test(NAME test_metadata1_cpp COMMAND test_metadata_cpp result_v1.ics)
+set_tests_properties(test_metadata1_cpp PROPERTIES DEPENDS test_ics1)
+add_test(NAME test_metadata2_cpp COMMAND test_metadata_cpp result_v2a.ics)
+set_tests_properties(test_metadata2_cpp PROPERTIES DEPENDS test_ics2a)
+add_test(NAME test_metadata3_cpp COMMAND test_metadata_cpp result_v2b.ics)
+set_tests_properties(test_metadata3_cpp PROPERTIES DEPENDS test_ics2b)
+if(LIBICS_USE_ZLIB)
+   add_test(NAME test_metadata4_cpp COMMAND test_metadata_cpp result_v2z.ics)
+   set_tests_properties(test_metadata4_cpp PROPERTIES DEPENDS test_gzip)
+endif()
+add_test(NAME test_history_cpp COMMAND test_history_cpp result_v1.ics)
+set_tests_properties(test_history_cpp PROPERTIES DEPENDS test_ics1)

--- a/support/cpp_interface/libics.cpp
+++ b/support/cpp_interface/libics.cpp
@@ -1,0 +1,459 @@
+/*
+ * libics: Image Cytometry Standard file reading and writing.
+ *
+ * C++ interface.
+ *
+ * Copyright 2018 Cris Luengo.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+/*
+ * FILE : libics.cpp
+ *
+ * This file defines functions for the C++ interface.
+ */
+
+
+#include <stdexcept>
+#include <cstring>
+
+#include "libics.hpp"
+#include "libics.h"
+
+#define ICS_FIELD_SEP '\t' // Copied from libics_ll.h
+
+namespace ics {
+
+void ICS::Open(std::string const& filename, std::string const& mode) {
+   if (ics) {
+      Close(); // Let's close the file first!
+   }
+   Ics_Error err = IcsOpen(&ics, filename.c_str(), mode.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::Close() {
+   Ics_Error err = IcsClose(ics);
+   ics = nullptr;
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+ICS::~ICS() {
+   if (ics) {
+      IcsClose(ics); // Ignore errors -- we cannot throw!
+   }
+}
+
+//void ICS::GetLayout() {
+ICS::Layout ICS::GetLayout() const {
+   Ics_DataType type;
+   int sz;
+   std::vector<std::size_t> dims(ICS_MAXDIM);
+   IcsGetLayout(ics, &type, &sz, dims.data());
+   dims.resize(static_cast<std::size_t>(sz));
+   DataType dt;
+   switch( type ) {
+      default:
+      case Ics_unknown:
+         dt = DataType::Unknown;
+         break;
+      case Ics_uint8:
+         dt = DataType::UInt8;
+         break;
+      case Ics_sint8:
+         dt = DataType::SInt8;
+         break;
+      case Ics_uint16:
+         dt = DataType::UInt16;
+         break;
+      case Ics_sint16:
+         dt = DataType::SInt16;
+         break;
+      case Ics_uint32:
+         dt = DataType::UInt32;
+         break;
+      case Ics_sint32:
+         dt = DataType::SInt32;
+         break;
+      case Ics_real32:
+         dt = DataType::Real32;
+         break;
+      case Ics_real64:
+         dt = DataType::Real64;
+         break;
+      case Ics_complex32:
+         dt = DataType::Complex32;
+         break;
+      case Ics_complex64:
+         dt = DataType::Complex64;
+         break;
+   }
+   return {dt, std::move(dims)};
+}
+
+void ICS::SetLayout(DataType dt, std::vector<std::size_t> const& dims) {
+   Ics_DataType type;
+   switch( dt ) {
+      default:
+      //case DataType::Unknown:
+         type = Ics_unknown;
+         break;
+      case DataType::UInt8:
+         type = Ics_uint8;
+         break;
+      case DataType::SInt8:
+         type = Ics_sint8;
+         break;
+      case DataType::UInt16:
+         type = Ics_uint16;
+         break;
+      case DataType::SInt16:
+         type = Ics_sint16;
+         break;
+      case DataType::UInt32:
+         type = Ics_uint32;
+         break;
+      case DataType::SInt32:
+         type = Ics_sint32;
+         break;
+      case DataType::Real32:
+         type = Ics_real32;
+         break;
+      case DataType::Real64:
+         type = Ics_real64;
+         break;
+      case DataType::Complex32:
+         type = Ics_complex32;
+         break;
+      case DataType::Complex64:
+         type = Ics_complex64;
+         break;
+   }
+   IcsSetLayout(ics, type, static_cast<int>(dims.size()), dims.data());
+}
+
+std::size_t ICS::GetDataSize() const {
+   return IcsGetDataSize(ics);
+}
+std::size_t ICS::GetImelSize() const {
+   return IcsGetImelSize(ics);
+}
+std::size_t ICS::GetImageSize() const {
+   return IcsGetImageSize(ics);
+}
+
+void ICS::GetData(void* dest, size_t n) {
+   Ics_Error err = IcsGetData(ics, dest, n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::GetROIData(std::vector<std::size_t> const& offset,
+                     std::vector<std::size_t> const& size,
+                     std::vector<std::size_t> const& sampling,
+                     void* dest,
+                     std::size_t n) {
+   Ics_Error err = IcsGetROIData(
+         ics,
+         offset.empty()   ? nullptr : offset.data(),
+         size.empty()     ? nullptr : size.data(),
+         sampling.empty() ? nullptr : sampling.data(),
+         dest, n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+// Read the image from an ICS file into a sub-block of a memory block. To use
+// the defaults strides, pass an empty vector. Only valid if reading.
+void ICS::GetDataWithStrides(void* dest, std::vector<std::ptrdiff_t> const& stride) {
+   Ics_Error err = IcsGetDataWithStrides(
+         ics, dest, 0,
+         stride.empty() ? nullptr : stride.data(),
+         stride.empty() ? (ics ? ics->dimensions : 0) : static_cast<int>(stride.size()));
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+
+// Read a portion of the image data from an ICS file. Only valid if reading.
+void ICS::GetDataBlock(void *dest, std::size_t n) {
+   Ics_Error err = IcsGetDataBlock(ics, dest, n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+
+/* Skip a portion of the image from an ICS file. Only valid if reading. */
+void ICS::SkipDataBlock(std::size_t n) {
+   Ics_Error err = IcsSkipDataBlock(ics, n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::GetPreviewData(void *dest, std::size_t n, std::size_t planeNumber) {
+   Ics_Error err = IcsGetPreviewData(ics, dest, n, planeNumber);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::SetData(void const* src, std::size_t n) {
+   Ics_Error err = IcsSetData(ics, src, n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::SetDataWithStrides(void const* src,
+                             std::size_t n,
+                             std::vector<ptrdiff_t> const& strides) {
+   Ics_Error err = IcsSetDataWithStrides(ics, src, n, strides.data(), static_cast<int>(strides.size()));
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::SetSource(std::string const& fname, std::size_t offset) {
+   Ics_Error err = IcsSetSource(ics, fname.c_str(), offset);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::SetByteOrder(ByteOrder order) {
+   Ics_Error err = IcsSetByteOrder(
+         ics,
+         order == ByteOrder::LittleEndian ? IcsByteOrder_littleEndian
+                                          : IcsByteOrder_bigEndian);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::SetCompression(Compression compression, int level) {
+   Ics_Error err = IcsSetCompression(
+         ics,
+         compression == Compression::GZip ? IcsCompr_gzip
+                                          : IcsCompr_uncompressed,
+         level );
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+Units ICS::GetPosition(int dimension) const {
+   char const* str;
+   Units units;
+   Ics_Error err = IcsGetPositionF(ics, dimension, &units.origin, &units.scale, &str);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   units.units = str;
+   return units;
+}
+
+void ICS::SetPosition(int dimension, Units const& units) {
+   Ics_Error err = IcsSetPosition(ics, dimension, units.origin, units.scale, units.units.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::GetOrder(int dimension,
+                   std::string& order,
+                   std::string& label) const {
+   char const* str_order;
+   char const* str_label;
+   Ics_Error err = IcsGetOrderF(ics, dimension, &str_order, &str_label);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   order = str_order;
+   label = str_label;
+}
+
+void ICS::SetOrder(int dimension,
+                   std::string const& order,
+                   std::string const& label) {
+   Ics_Error err = IcsSetOrder(ics, dimension, order.c_str(), label.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+std::string ICS::GetCoordinateSystem() const {
+   std::string coord;
+   coord.resize(ICS_STRLEN_TOKEN); // max length
+   Ics_Error err = IcsGetCoordinateSystem(ics, &(coord[0])); // TODO: this would be prettier as IcsGetCoordinateSystemF
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   coord.resize(std::strlen(&(coord[0])));
+   return coord;
+}
+
+void ICS::SetCoordinateSystem(std::string const& coord) {
+   Ics_Error err = IcsSetCoordinateSystem(ics, coord.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+std::size_t ICS::GetSignificantBits() const {
+   std::size_t nBits;
+   Ics_Error err = IcsGetSignificantBits(ics, &nBits);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   return nBits;
+}
+
+void ICS::SetSignificantBits(std::size_t nBits) {
+   Ics_Error err = IcsSetSignificantBits(ics, nBits);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+Units ICS::GetImelUnits() const {
+   char const* str;
+   Units units;
+   Ics_Error err = IcsGetImelUnitsF(ics, &units.origin, &units.scale, &str);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   units.units = str;
+   return units;
+}
+
+void ICS::SetImelUnits(Units const& units) {
+   Ics_Error err = IcsSetImelUnits(ics, units.origin, units.scale, units.units.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::AddHistoryString(std::string const& key, std::string const& value) {
+   Ics_Error err = IcsAddHistoryString(ics, key.c_str(), value.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void ICS::DeleteHistory(std::string const& key) {
+   Ics_Error err = IcsDeleteHistory(ics, key.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+int ICS::GetNumHistoryStrings() const {
+   int n;
+   Ics_Error err = IcsGetNumHistoryStrings(ics, &n);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   return n;
+}
+
+HistoryIterator::HistoryIterator(ICS& icsObj, std::string const& key) {
+   ics = icsObj.ics;
+   historyIterator = new Ics_HistoryIterator;
+   Ics_Error err = IcsNewHistoryIterator(ics, historyIterator, key.c_str());
+   if (err == IcsErr_EndOfHistory) {
+      return;
+   } else if (err != IcsErr_Ok) {
+      delete historyIterator;
+      historyIterator = nullptr;
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+HistoryIterator::~HistoryIterator() {
+   delete historyIterator;
+}
+
+std::string HistoryIterator::String() {
+   char const* str;
+   Ics_Error err = IcsGetHistoryStringIF(ics, historyIterator, &str);
+   if (err == IcsErr_EndOfHistory) {
+      return {};
+   } else if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   std::string out(str);
+   if (out.empty()) {
+      // This should not happen, but we want to avoid an empty string if we haven't reached
+      // the end of the history yet. Simply recurse until a valid entry was found.
+      return String();
+   }
+   return {str};
+}
+
+HistoryIterator::KeyValuePair HistoryIterator::KeyValue() {
+   char const* str;
+   Ics_Error err = IcsGetHistoryStringIF(ics, historyIterator, &str);
+   if (err == IcsErr_EndOfHistory) {
+      return {};
+   } else if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+   if (std::strlen(str) == 0) {
+      // This should not happen, but we want to avoid an empty string if we haven't reached
+      // the end of the history yet. Simply recurse until a valid entry was found.
+      return KeyValue();
+   }
+   char const *ptr = std::strchr(str, ICS_FIELD_SEP);
+   if (!ptr) {
+      // Let's assume we only have a key
+      return {std::string{str}, std::string{}};
+   }
+   return {std::string(str, static_cast<std::size_t>(ptr-str)), std::string(ptr + 1)};
+}
+
+void HistoryIterator::Delete() {
+   Ics_Error err = IcsDeleteHistoryStringI(ics, historyIterator);
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+void HistoryIterator::Replace(std::string const& key, std::string const& value) {
+   Ics_Error err = IcsReplaceHistoryStringI(ics, historyIterator, key.c_str(), value.c_str());
+   if (err != IcsErr_Ok) {
+      throw std::runtime_error(IcsGetErrorText(err));
+   }
+}
+
+std::string GetLibVersion() {
+   return IcsGetLibVersion();
+}
+
+int Version(std::string const& filename, bool forceName) {
+   return IcsVersion(filename.c_str(), forceName);
+}
+
+} // namespace ics

--- a/support/cpp_interface/libics.hpp
+++ b/support/cpp_interface/libics.hpp
@@ -1,0 +1,378 @@
+/*
+ * libics: Image Cytometry Standard file reading and writing.
+ *
+ * C++ interface.
+ *
+ * Copyright 2018 Cris Luengo.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+/*
+ * FILE : libics.hpp
+ *
+ * This is the only file you need to include in your C++ project
+ * if you don't want to use any of the low-level library functionality.
+ *
+ * The C++ interface throws exceptions where the C interface returns an
+ * error code, and uses RAII to prevent files not being closed and
+ * memory being leaked. Other than that, it provides identical
+ * functionality to the high-level interface in libics.h.
+ */
+
+
+#ifndef LIBICS_CPP_H
+#define LIBICS_CPP_H
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined(__WIN32__) && !defined(WIN32)
+#  define WIN32
+#endif
+
+#ifdef WIN32
+#  ifdef BUILD_ICSCPP
+#    define ICSCPPEXPORT __declspec(dllexport)
+#  else
+#    ifdef USE_ICSCPP_DLL
+#      define ICSCPPEXPORT __declspec(dllimport)
+#    else
+#      define ICSCPPEXPORT
+#    endif
+#  endif
+#else
+#  ifdef BUILD_ICSCPP
+#    define ICSCPPEXPORT __attribute__((visibility("default")))
+#  else
+#    define ICSCPPEXPORT
+#  endif
+#endif
+
+extern "C" {
+   struct _ICS;
+   struct _Ics_HistoryIterator;
+}
+
+namespace ics {
+
+enum class DataType {
+   Unknown = 0,
+   UInt8,     // integer, unsigned,  8 bpp
+   SInt8,     // integer, signed,    8 bpp
+   UInt16,    // integer, unsigned, 16 bpp
+   SInt16,    // integer, signed,   16 bpp
+   UInt32,    // integer, unsigned, 32 bpp
+   SInt32,    // integer, signed,   32 bpp
+   Real32,    // real,    signed,   32 bpp
+   Real64,    // real,    signed,   64 bpp
+   Complex32, // complex, signed, 2*32 bpp
+   Complex64  // complex, signed, 2*64 bpp
+};
+
+enum class Compression {
+   Uncompressed, // No compression
+   GZip          // Using zlib (ICS_ZLIB must be defined)
+};
+
+enum class ByteOrder {
+   LittleEndian, // Little endian byte order
+   BigEndian     // Big endian byte order
+};
+
+struct Units {
+   double origin;       // The position of each imel is given by
+   double scale;        // origin + coordinate * scale,
+   std::string units;   // in units.
+};                      // Imel intensities use the same concept.
+
+class ICS;
+
+
+// Use this to read history lines. This is a bit of an awkward iterator, we
+// adapted libics' iterator without trying to match the C++ iterator concept.
+// Repeated calls to `String` or `KeyValue` will produce all history lines.
+// An empty output indicates the end of the history has been reached.
+class HistoryIterator {
+public:
+
+   // Without a key, all history lines will be read. Otherwise only those with
+   // key equal to the string key will be read.
+   ICSCPPEXPORT explicit HistoryIterator(ICS &ics, std::string const &key = "");
+
+   HistoryIterator(HistoryIterator const &other) = delete;
+
+   HistoryIterator(HistoryIterator &&other) noexcept { swap(other); }
+
+   HistoryIterator &operator=(HistoryIterator const &other) = delete;
+
+   HistoryIterator &operator=(HistoryIterator &&other) noexcept {
+      swap(other);
+      return *this;
+   }
+
+   void swap(HistoryIterator &other) noexcept {
+      std::swap(historyIterator, other.historyIterator);
+   }
+
+   ICSCPPEXPORT ~HistoryIterator();
+
+   // Get the next history line as a single string.
+   // If there are no more history lines, returns an empty string.
+   ICSCPPEXPORT std::string String();
+
+   // Get the next history line as a key/value pair.
+   // If there are no more history lines, returns two empty strings.
+   struct KeyValuePair {
+      std::string key;
+      std::string value;
+   };
+   ICSCPPEXPORT KeyValuePair KeyValue();
+
+   // Delete last retrieved history line (iterator still points to the same
+   // string).
+   ICSCPPEXPORT void Delete();
+
+   // Replace last retrieved history line (iterator still points to the same
+   // string).
+   ICSCPPEXPORT void Replace(std::string const &key, std::string const &value);
+
+private:
+    // std::unique_ptr doesn't work with an incomplete type. We do not want to
+    // include "libics.h" here, so we need to work with incomplete types. A
+    // naked pointer is the best we can do I think.
+    struct _Ics_HistoryIterator *historyIterator = nullptr;
+    struct _ICS *ics = nullptr;   // Non-owning pointer to ICS data structure.
+};
+
+
+// This class encapsulates an ICS file.
+class ICS {
+   friend class HistoryIterator;
+public:
+
+   // The default constructor creates an object not associated to any files.
+   // Use Open to associate it with a file.
+   ICS() = default;
+
+   // This constructor creates the object and associates it to a file. See
+   // Open for the description of the parameters.
+   ICS(std::string const& filename, std::string const& mode) {
+      Open(filename, mode);
+   }
+
+   ICS(ICS const& other) = delete;
+   ICS(ICS&& other) noexcept { swap(other); }
+   ICS& operator=(ICS const& other) = delete;
+   ICS& operator=(ICS&& other) noexcept {
+      swap(other);
+      return *this;
+   }
+   void swap(ICS& other) noexcept {
+      std::swap(ics, other.ics);
+   }
+
+   // The destructor closes the ICS file. When writing, closing the file causes
+   // the data to be written. The destructor cannot inform of errors that occur
+   // during writing. The Close method throws an exception when an error occurs,
+   // use that function to catch errors.
+   ICSCPPEXPORT ~ICS();
+
+   // Open an ICS file for reading (mode = "r") or writing (mode = "w"). When
+   // writing, append a "2" to the mode string to create an ICS version 2.0
+   // file. Append an "f" to mode if, when reading, you want to force the file name
+   // to not change (no ".ics" is appended). Append a "l" to mode if, when reading,
+   // you don't want the locale forced to "C" (to read ICS files written with some
+   // other locale, set the locale properly then open the file with "rl").
+   ICSCPPEXPORT void Open(std::string const& filename, std::string const& mode);
+
+   // Close the ICS file. The ICS object is no longer associated to a file after
+   // calling this function.  No files are actually written until this function is
+   // called. Note that the destructor calls this function before exiting.
+   ICSCPPEXPORT void Close();
+
+   // Retrieve the layout of an ICS image. Only valid if reading.
+   struct Layout {
+      DataType dataType;
+      std::vector<std::size_t> dimensions;
+   };
+   ICSCPPEXPORT Layout GetLayout() const;
+
+   // Set the layout for an ICS image. Only valid if writing.
+   ICSCPPEXPORT void SetLayout(DataType dt, std::vector<std::size_t> const& dims);
+
+   // These three functions retrieve info from the ICS file.
+   // GetDataSize() == GetImelSize() * GetImageSize()
+   ICSCPPEXPORT std::size_t GetDataSize() const;
+   ICSCPPEXPORT std::size_t GetImelSize() const;
+   ICSCPPEXPORT std::size_t GetImageSize() const;
+
+   // Read the image data from an ICS file. Only valid if reading.
+   ICSCPPEXPORT void GetData(void* dest, std::size_t n);
+
+   // Read a square region of the image from an ICS file. To use the defaults in
+   // one of the parameters, pass an empty vector. Only valid if reading.
+   ICSCPPEXPORT void GetROIData(std::vector<std::size_t> const& offset,
+                                std::vector<std::size_t> const& size,
+                                std::vector<std::size_t> const& sampling,
+                                void* dest,
+                                std::size_t n);
+
+   // Read the image from an ICS file into a sub-block of a memory block. To use
+   // the defaults strides, pass an empty vector. Only valid if reading.
+   ICSCPPEXPORT void GetDataWithStrides(void* dest,
+                                        std::vector<std::ptrdiff_t> const& stride);
+
+   // Read a portion of the image data from an ICS file. Only valid if reading.
+   ICSCPPEXPORT void GetDataBlock(void *dest, std::size_t n);
+
+   // Skip a portion of the image from an ICS file. Only valid if reading.
+   ICSCPPEXPORT void SkipDataBlock(std::size_t n);
+
+   // Read a plane of the image data from an ICS file, and convert it to
+   // uint8. Only valid if reading.
+   ICSCPPEXPORT void GetPreviewData(void *dest,
+                                    std::size_t n,
+                                    std::size_t planeNumber);
+
+   // Set the image data for an ICS image. The pointer to this data must be
+   // accessible until Close has been called. Only valid if writing.
+   ICSCPPEXPORT void SetData(void const* src, std::size_t n);
+
+   // Set the image data for an ICS image. The pointer to this data must be
+   // accessible until Close has been called. Only valid if writing.
+   ICSCPPEXPORT void SetDataWithStrides(void const* src,
+                                        std::size_t n,
+                                        std::vector<ptrdiff_t> const& strides);
+
+   // Set the image source parameter for an ICS version 2.0 file. Only valid if
+   // writing.
+   ICSCPPEXPORT void SetSource(std::string const& fname, std::size_t offset);
+
+   // Set the image source byte order for an ICS version 2.0 file. Only valid if
+   // writing, and only valid after calling SetSource. If the data type is
+   // changed after this call, the byte order information written to file might
+   // not be correct.
+   ICSCPPEXPORT void SetByteOrder(ByteOrder order);
+
+   // Set the compression method and compression parameter. Only valid if
+   // writing.
+   ICSCPPEXPORT void SetCompression(Compression compression, int level = 9);
+
+   // Get the position of the image in the real world: the origin of the first
+   // pixel, the distances between pixels and the units in which to measure.
+   // Dimensions start at 0. Only valid if reading.
+   ICSCPPEXPORT Units GetPosition(int dimension) const;
+
+   // Set the position of the image in the real world: the origin of the first
+   // pixel, the distances between pixels and the units in which to measure.  If
+   // units.units is empty, it is set to the default value of "undefined".
+   // Dimensions start at 0. Only valid if writing.
+   ICSCPPEXPORT void SetPosition(int dimension,
+                                 Units const& units);
+
+   // Get the ordering of the dimensions in the image. The ordering is defined by
+   // names and labels for each dimension. The defaults are x, y, z, t (time) and p
+   // (probe). Dimensions start at 0. Only valid if reading.
+   ICSCPPEXPORT void GetOrder(int dimension,
+                              std::string& order,
+                              std::string& label) const;
+
+   // Set the ordering of the dimensions in the image. The ordering is defined by
+   // providing names and labels for each dimension. The defaults are x, y, z, t
+   // (time) and p (probe). Dimensions start at 0. Only valid if writing.
+   ICSCPPEXPORT void SetOrder(int dimension,
+                              std::string const& order,
+                              std::string const& label);
+
+   // Get the coordinate system used in the positioning of the pixels.  Related to
+   // GetPosition(). The default is "video". Only valid if reading.
+   ICSCPPEXPORT std::string GetCoordinateSystem() const;
+
+   // Set the coordinate system used in the positioning of the pixels.  Related to
+   // SetPosition(). The default is "video". Only valid if writing.
+   ICSCPPEXPORT void SetCoordinateSystem(std::string const& coord);
+
+   // Get the number of significant bits. Only valid if reading.
+   ICSCPPEXPORT std::size_t GetSignificantBits() const;
+
+   // Set the number of significant bits. Only valid if writing.
+   ICSCPPEXPORT void SetSignificantBits(std::size_t nBits);
+
+   // Set the position of the pixel values: the offset and scaling, and the units
+   // in which to measure. If you are not interested in one of the parameters, set
+   // the pointer to NULL. Only valid if reading.
+   ICSCPPEXPORT Units GetImelUnits() const;
+
+   // Set the position of the pixel values: the offset and scaling, and the units
+   // in which to measure. If units.units is empty, it is set to the default
+   // value of "relative". Only valid if writing.
+   ICSCPPEXPORT void SetImelUnits(Units const& units);
+
+   // Add history lines to the ICS file. key can be NULL
+   ICSCPPEXPORT void AddHistoryString(std::string const& key,
+                                      std::string const& value);
+
+   // Delete all history lines with key from ICS file. key can be empty, deletes
+   // all.
+   ICSCPPEXPORT void DeleteHistory(std::string const& key = "");
+
+   // Get the number of HISTORY lines from the ICS file.
+   ICSCPPEXPORT int GetNumHistoryStrings() const;
+
+   HistoryIterator NewHistoryIterator(std::string const &key = "") {
+      return HistoryIterator(*this, key);
+   }
+
+private:
+   // std::unique_ptr doesn't work with an incomplete type. We do not want to
+   // include "libics.h" here, so we need to work with incomplete types. A
+   // naked pointer is the best we can do I think.
+   struct _ICS* ics = nullptr;
+};
+
+// Returns a string that can be used to compare with ICSLIB_VERSION to check if
+// the version of the library is the same as that of the headers.
+inline std::string GetLibVersion();
+
+// Returns 0 if it is not an ICS file, or the version number if it is.
+// If forceName is true, no extension is appended.
+inline int Version(std::string const& filename, bool forceName);
+
+// Read a preview (2D) image out of an ICS file. dest is resized, and xsize
+// and ysize are set to the image size.
+inline void LoadPreview(std::string const& filename,
+                        std::size_t planeNumber,
+                        std::vector<std::uint8_t>& dest,
+                        std::size_t& xsize,
+                        std::size_t& ysize) {
+   ICS ics(filename, "r");
+   auto layout = ics.GetLayout();
+   if (layout.dimensions.size() < 2 ) {
+      throw std::runtime_error("Image has fewer than two dimensions");
+   }
+   std::size_t n = layout.dimensions[ 0 ] * layout.dimensions[ 1 ];
+   dest.resize(n);
+   ics.GetPreviewData(dest.data(), n, planeNumber);
+   ics.Close();
+   xsize = layout.dimensions[ 0 ];
+   ysize = layout.dimensions[ 1 ];
+}
+
+} // namespace ics
+
+#endif // LIBICS_CPP_H

--- a/support/cpp_interface/test_history.cpp
+++ b/support/cpp_interface/test_history.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include "libics.hpp"
+
+int main(int argc, const char* argv[]) {
+
+   constexpr char const* token1 = "sequence1cpp";
+   constexpr char const* token2 = "sequence2cpp";
+   constexpr char const* stuff1 = "this is some data";
+   constexpr char const* stuff2 = "this is some more data";
+   constexpr char const* stuff3 = "this is some other stuff";
+
+   if (argc != 2) {
+      std::cerr << "One file names required\n";
+      exit(-1);
+   }
+
+   try {
+
+      // Open image for update
+      ics::ICS ip(argv[1], "rw");
+
+      // Remove history lines
+      ip.DeleteHistory("testcpp");   // delete history line added by test_metadata.cpp
+
+      // Add history lines
+      ip.AddHistoryString(token1, stuff1);
+      ip.AddHistoryString(token1, stuff2);
+      ip.AddHistoryString(token2, stuff3);
+
+      // Check
+      if (ip.GetNumHistoryStrings() != 3) {
+         std::cerr << "Number of history lines not correct.\n";
+         exit(-1);
+      }
+
+      // Read history lines and compare
+      auto it = ip.NewHistoryIterator();
+      auto pair = it.KeyValue();
+      if (pair.key != token1 || pair.value != stuff1) {
+         std::cerr << "1st history string does not match: \"" << pair.key << '/' << pair.value
+                   << "\" vs \"" << token1 << '/' << stuff1 << "\"\n";
+         exit(-1);
+      }
+      pair = it.KeyValue();
+      if (pair.key != token1 || pair.value != stuff2) {
+         std::cerr << "2nd history string does not match: \"" << pair.key << '/' << pair.value
+                   << "\" vs \"" << token1 << '/' << stuff2 << "\"\n";
+         exit(-1);
+      }
+      pair = it.KeyValue();
+      if (pair.key != token2 || pair.value != stuff3) {
+         std::cerr << "3rd history string does not match: \"" << pair.key << '/' << pair.value
+                   << "\" vs \"" << token2 << '/' << stuff3 << "\"\n";
+         exit(-1);
+      }
+
+      // Check earlier deleted line
+      it = ip.NewHistoryIterator("testcpp");
+      if (!it.String().empty()) {
+         std::cerr << "Did not properly delete original 'testcpp' line.\n";
+         exit(-1);
+      }
+
+      // Read token2 line
+      it = ip.NewHistoryIterator(token2);
+      pair = it.KeyValue();
+      if (pair.key != token2 || pair.value != stuff3) {
+         std::cerr << "history string does not match.\n";
+         exit(-1);
+      }
+
+      // Commit changes
+      ip.Close();
+
+   } catch (std::exception const& e) {
+      std::cerr << "Exception thrown in libics: " << e.what() << '\n';
+      exit(-1);
+   }
+}

--- a/support/cpp_interface/test_ics2a.cpp
+++ b/support/cpp_interface/test_ics2a.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <memory>
+#include <cstdint>
+#include <cstring>
+#include "libics.hpp"
+
+int main(int argc, const char* argv[]) {
+   if (argc != 3) {
+      std::cerr << "Two file names required: in out\n";
+      exit(-1);
+   }
+
+   try {
+
+      // Read image
+      ics::ICS ip(argv[1], "r");
+      auto layout = ip.GetLayout();
+      std::size_t bufsize = ip.GetDataSize();
+      std::unique_ptr<std::uint8_t[]> buf1{new std::uint8_t[bufsize]};
+      ip.GetData(buf1.get(), bufsize);
+      ip.Close();
+
+      // Write image
+      ip.Open(argv[2], "w2");
+      ip.SetLayout(layout.dataType, layout.dimensions);
+      std::string datafile{argv[1]};
+      auto pos = datafile.rfind('.');
+      if (pos != std::string::npos) {
+         datafile.erase(pos);
+      }
+      datafile += ".ids";
+      ip.SetSource(datafile, 0);
+      ip.SetByteOrder(ics::ByteOrder::LittleEndian);
+      ip.SetCompression(ics::Compression::Uncompressed, 0);
+      ip.Close();
+
+      // Read image
+      ip.Open(argv[2], "r");
+      if (bufsize != ip.GetDataSize()) {
+         std::cerr << "Data in output file not same size as written.\n";
+         exit(-1);
+      }
+      std::unique_ptr<std::uint8_t[]> buf2{new std::uint8_t[bufsize]};
+      ip.GetData(buf2.get(), bufsize);
+      ip.Close();
+      if (memcmp(buf1.get(), buf2.get(), bufsize) != 0) {
+         std::cerr << "Data in output file does not match data in input.\n";
+         exit(-1);
+      }
+
+   } catch (std::exception const& e) {
+      std::cerr << "Exception thrown in libics: " << e.what() << '\n';
+      exit(-1);
+   }
+}

--- a/support/cpp_interface/test_ics2b.cpp
+++ b/support/cpp_interface/test_ics2b.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <memory>
+#include <cstdint>
+#include <cstring>
+#include "libics.hpp"
+
+int main(int argc, const char* argv[]) {
+
+   if (argc != 3) {
+      std::cerr << "Two file names required: in out\n";
+      exit(-1);
+   }
+
+   try {
+
+      // Read image
+      ics::ICS ip(argv[1], "r");
+      auto layout = ip.GetLayout();
+      std::size_t bufsize = ip.GetDataSize();
+      std::unique_ptr<std::uint8_t[]> buf1{new std::uint8_t[bufsize]};
+      ip.GetData(buf1.get(), bufsize);
+      ip.Close();
+
+      // Write image
+      ip.Open(argv[2], "w2");
+      ip.SetLayout(layout.dataType, layout.dimensions);
+      ip.SetData(buf1.get(), bufsize);
+      ip.SetCompression(ics::Compression::Uncompressed, 0);
+      ip.Close();
+
+      // Read image
+      ip.Open(argv[2], "r");
+      if (bufsize != ip.GetDataSize()) {
+         std::cerr << "Data in output file not same size as written.\n";
+         exit(-1);
+      }
+      std::unique_ptr<std::uint8_t[]> buf2{new std::uint8_t[bufsize]};
+      ip.GetData(buf2.get(), bufsize);
+      ip.Close();
+      if (memcmp(buf1.get(), buf2.get(), bufsize) != 0) {
+         std::cerr << "Data in output file does not match data in input.\n";
+         exit(-1);
+      }
+
+   } catch (std::exception const& e) {
+      std::cerr << "Exception thrown in libics: " << e.what() << '\n';
+      exit(-1);
+   }
+}

--- a/support/cpp_interface/test_metadata.cpp
+++ b/support/cpp_interface/test_metadata.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <memory>
+#include <cstdint>
+#include <cstring>
+#include "libics.hpp"
+
+int main(int argc, const char* argv[]) {
+
+   if (argc != 2) {
+      std::cerr << "One file name required\n";
+      exit(-1);
+   }
+
+   try {
+
+      // Open image for update
+      ics::ICS ip(argv[1], "rw");
+      auto layout = ip.GetLayout();
+      std::size_t bufsize = ip.GetDataSize();
+      std::unique_ptr<std::uint8_t[]> buf1{new std::uint8_t[bufsize]};
+      ip.GetData(buf1.get(), bufsize);
+
+      // Add and change metadata
+      ip.SetPosition(0, {5.7, 1.3, "m"});
+      ip.SetPosition(1, {-8.2, 1.2, "meter"});
+      ip.DeleteHistory();
+      ip.AddHistoryString("testcpp", "Adding history line.");
+
+      // Commit changes
+      ip.Close();
+
+      // Read image
+      ip.Open(argv[1], "r");
+
+      // Check metadata
+      auto units = ip.GetPosition(0);
+      if (units.origin != 5.7 || units.scale != 1.3 || units.units != "m") {
+         std::cerr << "Different position metadata read back\n";
+         exit(-1);
+      }
+      units = ip.GetPosition(1);
+      if (units.origin != -8.2 || units.scale != 1.2 || units.units != "meter") {
+         std::cerr << "Different position metadata read back\n";
+         exit(-1);
+      }
+      auto it = ip.NewHistoryIterator();
+      auto pair = it.KeyValue();
+      if (pair.key != "testcpp" || pair.value != "Adding history line.") {
+         std::cerr << "Different history key/value pair read back\n";
+         exit(-1);
+      }
+
+      // Check pixel data
+      if (bufsize != ip.GetDataSize()) {
+         std::cerr << "Data in output file not same size as written.\n";
+         exit(-1);
+      }
+      std::unique_ptr<std::uint8_t[]> buf2{new std::uint8_t[bufsize]};
+      ip.GetData(buf2.get(), bufsize);
+      ip.Close();
+      if (memcmp(buf1.get(), buf2.get(), bufsize) != 0) {
+         std::cerr << "Data in output file does not match data in input.\n";
+         exit(-1);
+      }
+
+   } catch (std::exception const& e) {
+      std::cerr << "Exception thrown in libics: " << e.what() << '\n';
+      exit(-1);
+   }
+}


### PR DESCRIPTION
I've separated out my changes into separate commits so you can pick what you want to include:

- The first 3 commits are minor fixes.

- d4a932d improves one of the tests to be more rigorous.

- 8f168c7 adds a function `IcsSetByteOrder` to specify the byte order of data in an external file (when you use `IcsSetSource` instead of `IcsSetData`). This fixes an ugly hack in one of the tests.

- 3a9a748 adds a C++ interface. It exposes the high-level interface defined in `libics.h`, but in a namespace to prevent namespace pollution; the `ICS` class uses RAII so you don't need to remember to close the file; and functions throw an exception instead of returning an error code, so it is not necessary to explicitly check return codes all the time. Only one file needs to be included in a C++ program: `libics.hpp`. The C++ functions are exported from the same libics library.

    With CMake, you can do `cmake <path> -DLIBICS_INCLUDE_CPP=Off` to not compile the C++ interface. With Automake the C++ interface is not yet compiled (TODO). There are a few test programs for the C++ interface (these still need to be added to the Automake scripts too).

    This commit also reorders a few things in the CMake script, but the only functional changes are the addition of instructions for the C++ interface and tests.
