### PR TITLE
Fix repository's incorrect language-classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
 # Fix incorrect language classifications on GitHub.com
+/aclocal.m4 linguist-vendored
 /autom4te.cache/* linguist-language=text linguist-generated=true
+/compile linguist-vendored
+/config.* linguist-vendored
 /configure linguist-vendored
+/depcomp linguist-vendored
+/install-sh linguist-vendored
+/ltmain.sh linguist-vendored
+/m4/* linguist-vendored
+/Makefile.in linguist-vendored
+/missing linguist-vendored
+/test-driver linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Fix incorrect language classifications on GitHub.com
-/autom4te.cache/* linguist-language=text
+/autom4te.cache/* linguist-language=text linguist-generated=true
+/configure linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix incorrect language classifications on GitHub.com
+/autom4te.cache/* linguist-language=text


### PR DESCRIPTION
👋 I saw this repo being misclassified as Roff (after coming here through github/linguist#4418). This is a small patch which corrects this problem; it uses [an override](https://github.com/github/linguist#overrides) to mark the incorrectly classified files as plain text, not Roff.

The problem is the numeric file extensions, which Linguist mistakes as man-pages. This is a [known issue](https://github.com/github/linguist/pull/4258) and currently being worked on.