### PR TITLE
Add -no-undefined to LDFLAGS to build shared library on MinGW-w64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ ACLOCAL_AMFLAGS = -I m4
 AUTOMAKE_OPTIONS = foreign
 
 lib_LTLIBRARIES = libics.la
-libics_la_LDFLAGS = -version-info $(ICS_LT_VERSION)
+libics_la_LDFLAGS = -version-info $(ICS_LT_VERSION) -no-undefined
 
 # list all sources and include files that are not installed, but are
 # distributed, except for libics_conf.h, which is generated from


### PR DESCRIPTION
This enables building a `.dll` shared library on Windows using MinGW-w64 by adding `-no-undefined` to `LDFLAGS`.