### PR TITLE
Initialize idx2 to NULL

### DIFF
--- a/libics_read.c
+++ b/libics_read.c
@@ -242,7 +242,7 @@ static Ics_Error getIcsCat(char        *str,
                            const char **index2)
 {
     ICSINIT;
-    char *token, buffer[ICS_LINE_LENGTH], *idx1, *idx2;
+    char *token, buffer[ICS_LINE_LENGTH], *idx1, *idx2 = NULL;
 #ifdef HAVE_STRTOK_R
     char *saveptr;
 #endif


### PR DESCRIPTION
Why? At least gcc was giving a warning:

```
/mnt/2/s/libs/libics/libics_read.c: In function ‘IcsReadIcs’:
/mnt/2/s/libs/libics/libics_read.c:278:36: warning: ‘idx2’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                     *index2 = idx2 + 1;
                               ~~~~~^~~
/mnt/2/s/libs/libics/libics_read.c:245:51: note: ‘idx2’ was declared here
     char *token, buffer[ICS_LINE_LENGTH], *idx1, *idx2;
                                                   ^~~~
```

Yes, it may be a false alarm... But nevertheless clearer this way, I think.