### PR TITLE
Avoid null pointer dereferencing

### DIFF
--- a/libics.h
+++ b/libics.h
@@ -508,6 +508,8 @@ typedef enum {
     IcsErr_MissSensorSubCat,
         /* Missing sensor subsubcategory: */
     IcsErr_MissSensorSubSubCat,
+        /* Missing sensor subsubcategory index: */
+    IcsErr_MissSensorSubSubCatIndex,
         /* Missing sub category: */
     IcsErr_MissSubCat,
         /* There is no Data defined: */

--- a/libics_read.c
+++ b/libics_read.c
@@ -717,43 +717,58 @@ Ics_Error IcsReadIcs(Ics_Header *icsStruct,
                                 break;
                             case ICSTOK_DETOFFSET:
                                 while (ptr != NULL && i < ICS_MAX_LAMBDA) {
-                                    detID = atoi(idx1);
-                                    switch (idx2[0]) {
-                                        case  'X':
-                                            icsStruct->
-                                                detectorOffset[i++][detID][0]
-                                                = atof(ptr);
-                                            break;
-                                        case  'Y':
-                                            icsStruct->
-                                                detectorOffset[i++][detID][1]
-                                                = atof(ptr);
-                                            break;
-                                        case  'Z':
-                                            icsStruct->
-                                                detectorOffset[i++][detID][2]
-                                                = atof(ptr);
-                                            break;
-                                        default:
-                                            break;
+                                    if (idx1 && idx2) {
+                                        detID = atoi(idx1);
+                                        switch (idx2[0]) {
+                                            case 'X':
+                                                icsStruct->
+                                                    detectorOffset[i++][detID][0]
+                                                    = atof(ptr);
+                                                break;
+                                            case 'Y':
+                                                icsStruct->
+                                                    detectorOffset[i++][detID][1]
+                                                    = atof(ptr);
+                                                break;
+                                            case 'Z':
+                                                icsStruct->
+                                                    detectorOffset[i++][detID][2]
+                                                    = atof(ptr);
+                                                break;
+                                            default:
+                                                break;
+                                        }
+                                        ptr = STRTOK(NULL, seps);
+                                    } else {
+                                        error = IcsErr_MissSensorSubSubCatIndex;
+                                        break;
                                     }
-                                    ptr = STRTOK(NULL, seps);
                                 }
                                 break;
                             case ICSTOK_DETSENS:
                                 while (ptr != NULL && i < ICS_MAX_LAMBDA) {
-                                    detID = atoi(idx1);
-                                    icsStruct->detectorSensitivity[i++][detID]
-                                        = atof(ptr);
-                                    ptr = STRTOK(NULL, seps);
+                                    if (idx1) {
+                                        detID = atoi(idx1);
+                                        icsStruct->detectorSensitivity[i++][detID]
+                                            = atof(ptr);
+                                        ptr = STRTOK(NULL, seps);
+                                    } else {
+                                        error = IcsErr_MissSensorSubSubCatIndex;
+                                        break;
+                                    }
                                 }
                                 break;
                             case ICSTOK_DETRADIUS:
-                                    /* This is a temporary fix to provide
-                                       support for ics files with a non-vector
+                                if (idx1) {
+                                    /* This supports ics files with a non-vector
                                        detector radius. */
-                                    /* Todo: Remove this in due time. */
-                                if (idx1 == NULL) {
+                                    while (ptr != NULL && i < ICS_MAX_LAMBDA) {
+                                        detID = atoi(idx1);
+                                        icsStruct->detectorRadius[i++][detID]
+                                            = atof(ptr);
+                                        ptr = STRTOK(NULL, seps);
+                                    }
+                                } else {
                                     printf("Using non-vector detRadius.\n");
                                     if (ptr != NULL) {
                                         printf("Filling vector with single "
@@ -767,13 +782,6 @@ Ics_Error IcsReadIcs(Ics_Header *icsStruct,
                                             }
                                         }
                                     }
-                                    break;
-                                }
-                                while (ptr != NULL && i < ICS_MAX_LAMBDA) {
-                                    detID = atoi(idx1);
-                                    icsStruct->detectorRadius[i++][detID]
-                                        = atof(ptr);
-                                    ptr = STRTOK(NULL, seps);
                                 }
                                 break;
                             case ICSTOK_DETSCALE:
@@ -823,23 +831,28 @@ Ics_Error IcsReadIcs(Ics_Header *icsStruct,
                                 break;
                             case ICSTOK_SPIMPLANEPROPDIR:
                                 while (ptr != NULL && i < ICS_MAX_LAMBDA) {
-                                    switch (idx1[0]) {
-                                        case  'X':
-                                            icsStruct->spimPlanePropDir[i++][0]
-                                                = atof(ptr);
-                                            break;
-                                        case  'Y':
-                                            icsStruct->spimPlanePropDir[i++][1]
-                                                = atof(ptr);
-                                            break;
-                                        case  'Z':
-                                            icsStruct->spimPlanePropDir[i++][2]
-                                                = atof(ptr);
-                                            break;
-                                        default:
-                                            break;
+                                    if (idx1) {
+                                        switch (idx1[0]) {
+                                            case 'X':
+                                                icsStruct->spimPlanePropDir[i++][0]
+                                                    = atof(ptr);
+                                                break;
+                                            case 'Y':
+                                                icsStruct->spimPlanePropDir[i++][1]
+                                                    = atof(ptr);
+                                                break;
+                                            case 'Z':
+                                                icsStruct->spimPlanePropDir[i++][2]
+                                                    = atof(ptr);
+                                                break;
+                                            default:
+                                                break;
+                                        }
+                                        ptr = STRTOK(NULL, seps);
+                                    } else {
+                                        error = IcsErr_MissSensorSubSubCatIndex;
+                                        break;
                                     }
-                                    ptr = STRTOK(NULL, seps);
                                 }
                                 break;
                             case ICSTOK_SPIMPLANECENTEROFF:

--- a/libics_read.c
+++ b/libics_read.c
@@ -220,7 +220,7 @@ static Ics_Token getIcsToken(char           *str,
 
         /* Because some older ics versions have uncapitalized subsubcat
            symbols (e.g. "channels" instead of the current "Channels"), do a
-           case insenstive string comparison for backward compatiblity. */
+           case-insensitive string comparison for backward compatibility. */
     if (str != NULL) {
         for (i = 0; i < listSpec->entries; i++) {
             if (ICSSTRCASECMP(listSpec->list[i].name, str) == 0) {
@@ -266,16 +266,14 @@ static Ics_Error getIcsCat(char        *str,
                 idx1 = strchr(token, '[');
                 if (idx1) {
                     idx2 = strchr(idx1 + 1, '[');
-                }
-                if (idx1) {
                         /* Todo: Check that this line is indeed not
-                            //necessary. */
+                                 necessary. */
                         /* token[strlen(token) - 1] = '\0'; */
                     *idx1 = '\0';
                     *index1 = idx1 + 1;
-                }
-                if (idx2) {
-                    *index2 = idx2 + 1;
+                    if (idx2) {
+                        *index2 = idx2 + 1;
+                    }
                 }
             }
             *subSubCat = getIcsToken(token, &G_SubSubCategories);

--- a/libics_sensor.c
+++ b/libics_sensor.c
@@ -751,7 +751,6 @@ Ics_Error IcsGetSensorParameterMatrix(const ICS             *ics,
                                       const double         **values,
                                       Ics_SensorState       *state)
 {
-    int p;
     if (channel < 0 || channel >= ics->sensorChannels) {
         return IcsErr_NotValidAction;
     }

--- a/libics_top.c
+++ b/libics_top.c
@@ -1222,9 +1222,6 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_EndOfStream:
             msg = "Unexpected end of stream";
             break;
-        case IcsErr_FailWriteLine:
-            msg = "Failed to write a line in .ics file";
-            break;
         case IcsErr_FCloseIcs:
             msg = "File close error on .ics file";
             break;
@@ -1256,8 +1253,8 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_FWriteIds:
             msg = "File write error on .ids file";
             break;
-        case IcsErr_IllegalROI:
-            msg = "The given ROI extends outside the image";
+        case IcsErr_FailWriteLine:
+            msg = "Failed to write a line in .ics file";
             break;
         case IcsErr_IllIcsToken:
             msg = "Illegal ICS token detected";
@@ -1265,6 +1262,9 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_IllParameter:
             msg = "A function parameter has a value that is not legal or does "
                 "not match with a value previously given";
+            break;
+        case IcsErr_IllegalROI:
+            msg = "The given ROI extends outside the image";
             break;
         case IcsErr_LineOverflow:
             msg = "Line overflow in .ics file";
@@ -1274,9 +1274,6 @@ const char *IcsGetErrorText(Ics_Error error)
             break;
         case IcsErr_MissCat:
             msg = "Missing main category";
-            break;
-        case IcsErr_MissingData:
-            msg = "There is no Data defined";
             break;
         case IcsErr_MissLayoutSubCat:
             msg = "Missing layout subcategory";
@@ -1296,6 +1293,9 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_MissSubCat:
             msg = "Missing sub category";
             break;
+        case IcsErr_MissingData:
+            msg = "There is no Data defined";
+            break;
         case IcsErr_NoLayout:
             msg = "Layout parameters missing or not defined";
             break;
@@ -1308,11 +1308,11 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_NotValidAction:
             msg = "The function won't work on the ICS given";
             break;
-        case IcsErr_TooManyChans:
-            msg = "Too many channels specified";
-            break;
         case IcsErr_TooManyDetectors:
             msg = "Too many detectors specified";
+            break;
+        case IcsErr_TooManyChans:
+            msg = "Too many channels specified";
             break;
         case IcsErr_TooManyDims:
             msg = "Data has too many dimensions";

--- a/libics_top.c
+++ b/libics_top.c
@@ -1290,6 +1290,9 @@ const char *IcsGetErrorText(Ics_Error error)
         case IcsErr_MissSensorSubSubCat:
             msg = "Missing sensor subsubcategory";
             break;
+        case IcsErr_MissSensorSubSubCatIndex:
+            msg = "Missing sensor subsubcategory index";
+            break;
         case IcsErr_MissSubCat:
             msg = "Missing sub category";
             break;


### PR DESCRIPTION
This PR fixes some potential null pointer dereferencing:
- If there's a `]` at the end of a line, but no opening `[` (as reported in #19, this PR provides a better fix).
- If the `[` or `]` are missing from sensor parameters that expect them (new code will report an error in this case).

There's also a commit that removes an unused variable, which replicates the fix in #18.

And another commit reorders cases in `IcsGetErrorText` to match the `enum` (I'm a neat freak).

Some comments:

- It would be really good to create a few test cases for the new sensor parameters, to ensure that code changes don't break that functionality.

- The very short code lines imposed by your coding standard don't mesh well with the way too long `IcsReadIcs` function. This function has such deep indenting that just about every line of code is split across multiple lines, making the code hard to read. The new sensor parameters also make this function even longer than it already was. I suggest you refactor this function, delegating the sub-sub-category parsing  to separate functions (and maybe even the sub-category parsing too).
