### PR TITLE
Avoid unsafe sprintf

### DIFF
--- a/libics_write.c
+++ b/libics_write.c
@@ -242,7 +242,7 @@ static Ics_Error icsAddInt(char     *line,
     char intStr[ICS_STRLEN_OTHER];
 
 
-    sprintf(intStr, "%ld%c", i, ICS_FIELD_SEP);
+    snprintf(intStr, ICS_STRLEN_OTHER, "%ld%c", i, ICS_FIELD_SEP);
     if (strlen(line) + strlen(intStr) + 1 > ICS_LINE_LENGTH)
         return IcsErr_LineOverflow;
     strcat(line, intStr);
@@ -258,7 +258,7 @@ static Ics_Error icsAddLastInt(char     *line,
     char intStr[ICS_STRLEN_OTHER];
 
 
-    sprintf(intStr, "%ld%c", i, ICS_EOL);
+    snprintf(intStr, ICS_STRLEN_OTHER, "%ld%c", i, ICS_EOL);
     if (strlen(line) + strlen(intStr) + 1 > ICS_LINE_LENGTH)
         return IcsErr_LineOverflow;
     strcat(line, intStr);
@@ -275,9 +275,9 @@ static Ics_Error icsAddDouble(char   *line,
 
 
     if (d == 0 ||(fabs(d) < ICS_MAX_DOUBLE && fabs(d) >= ICS_MIN_DOUBLE)) {
-        sprintf(dStr, "%f%c", d, ICS_FIELD_SEP);
+        snprintf(dStr, ICS_STRLEN_OTHER, "%f%c", d, ICS_FIELD_SEP);
     } else {
-        sprintf(dStr, "%e%c", d, ICS_FIELD_SEP);
+        snprintf(dStr, ICS_STRLEN_OTHER, "%e%c", d, ICS_FIELD_SEP);
     }
     if (strlen(line) + strlen(dStr) + 1 > ICS_LINE_LENGTH)
         return IcsErr_LineOverflow;
@@ -295,9 +295,9 @@ static Ics_Error icsAddLastDouble(char   *line,
 
 
     if (d == 0 || (fabs(d) < ICS_MAX_DOUBLE && fabs(d) >= ICS_MIN_DOUBLE)) {
-        sprintf(dStr, "%f%c", d, ICS_EOL);
+        snprintf(dStr, ICS_STRLEN_OTHER, "%f%c", d, ICS_EOL);
     } else {
-        sprintf(dStr, "%e%c", d, ICS_EOL);
+        snprintf(dStr, ICS_STRLEN_OTHER, "%e%c", d, ICS_EOL);
     }
     if (strlen(line) + strlen(dStr) + 1 > ICS_LINE_LENGTH)
         return IcsErr_LineOverflow;
@@ -836,7 +836,7 @@ static Ics_Error writeIcsSensorData(Ics_Header *icsStruct,
         ICS_ADD_SENSOR_DOUBLE(ICSTOK_DETNOISEGAIN, detectorNoiseGain);
 
         for (j = 0; j < icsStruct->sensorDetectors; j++) {
-            sprintf(tag, "%d", j);
+            snprintf(tag, ICS_STRLEN_OTHER, "%d", j);
             ICS_ADD_SENSOR_DOUBLE_2INDICES(ICSTOK_DETOFFSET, detectorOffset,
                                            tag, "X", j, 0);
             ICS_ADD_SENSOR_DOUBLE_2INDICES(ICSTOK_DETOFFSET, detectorOffset,
@@ -845,12 +845,12 @@ static Ics_Error writeIcsSensorData(Ics_Header *icsStruct,
                                            tag, "Z", j, 2);
         }
         for (j = 0; j < icsStruct->sensorDetectors; j++) {
-            sprintf(tag, "%d", j);
+            snprintf(tag, ICS_STRLEN_OTHER, "%d", j);
             ICS_ADD_SENSOR_DOUBLE_INDEX(ICSTOK_DETSENS, detectorSensitivity,
                                         tag, j);
         }
         for (j = 0; j < icsStruct->sensorDetectors; j++) {
-            sprintf(tag, "%d", j);
+            snprintf(tag, ICS_STRLEN_OTHER, "%d", j);
             ICS_ADD_SENSOR_DOUBLE_INDEX(ICSTOK_DETRADIUS, detectorRadius,
                                         tag, j);
         }

--- a/support/cpp_interface/libics.hpp
+++ b/support/cpp_interface/libics.hpp
@@ -37,6 +37,7 @@
 #ifndef LIBICS_CPP_H
 #define LIBICS_CPP_H
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/support/icsviewer/readics.c
+++ b/support/icsviewer/readics.c
@@ -10,6 +10,7 @@ int IsICS (char *filename) {
 }
 
 int NumberOfPlanesInICS (char *filename, char *errortext) {
+   /* errortext must point to ERRORTEXT_LENGTH=300 bytes. */
    ICS* ip;
    Ics_Error retval;
    int ii, numberofplanes = 0;
@@ -97,7 +98,7 @@ HANDLE ReadICS (char *filename, char *errortext) {
    padding = ((dims[0]+3)/4)*4 - dims[0];
 
    /*
-   sprintf (errortext, "Image size: %d x %d. Padding = %d.", dims[0], dims[1], padding);
+   snprintf (errortext, ERRORTEXT_LENGTH, "Image size: %d x %d. Padding = %d.", dims[0], dims[1], padding);
    MessageBox (0, errortext, "ICSviewer", MB_ICONINFORMATION|MB_OK);
    */
 

--- a/support/icsviewer/viewer.c
+++ b/support/icsviewer/viewer.c
@@ -4,6 +4,7 @@
 #include "..\..\libics.h"
 
 /* Functions in readics.c */
+#define ERRORTEXT_LENGTH 300
 HANDLE ReadICS (char *filename, char *errortext);
 int NumberOfPlanesInICS (char *filename, char *errortext);
 /* Functions in writedib.c */
@@ -17,7 +18,7 @@ LPCTSTR lpszAppName  = "IcsViewer";
 LPCTSTR lpszTitle    = "ICS Viewer Test";
 HANDLE DIB;
 BITMAPINFO* bi;
-char errortext[300];
+char errortext[ERRORTEXT_LENGTH];
 char filename[300];
 
 /**********************************************************************/
@@ -74,7 +75,7 @@ int LoadICSFile( HWND hWnd, char *filename )
       return 0L;
    }
    else {
-      //sprintf (errortext, "%d planes in file.", planes);
+      //snprintf (errortext, ERRORTEXT_LENGTH, "%d planes in file.", planes);
       //MessageBox (hWnd, errortext, "ICSviewer", MB_ICONINFORMATION|MB_OK);
    }
 
@@ -174,7 +175,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
                   strcat( ofn.lpstrFile, ".bmp" );
 
                /*
-               sprintf( textBuf, "Saving to %s", ofn.lpstrFile );
+               snprintf( textBuf, ERRORTEXT_LENGTH, "Saving to %s", ofn.lpstrFile );
                MessageBox( hWnd, textBuf, "Boo", MB_OK|MB_ICONINFORMATION );
                */
 

--- a/support/matlab/README
+++ b/support/matlab/README
@@ -38,15 +38,18 @@ ICSWRITE   Writes a numeric array to an ICS file.
 COMPILING
 =========
 
-If your version of MATLAB is 7.3 or newer, remove the line at
-the top of both source files that defines mwSize.
+If your version of MATLAB is 7.2 or older, uncomment the line at
+the top of both source files that defines `mwSize`.
 
-Within MATLAB (on UNIX), type
-  mex -I<icspath> icsread.c <icspath>/libics.a <zpath>/libz.a
-  mex -I<icspath> icswrite.c <icspath>/libics.a <zpath>/libz.a
-from the directory containing both source files.
+- UNIX or macOS:
+Within MATLAB, type
+  mex -I<icspath> icsread.c <icspath>/libics.a -lz
+  mex -I<icspath> icswrite.c <icspath>/libics.a -lz
+from the directory containing both source files. If the Zlib library is not in a standard location, you will have
+to specify it explicitly, replace `-lz` with `<zlibpath>/libz.a`.
 
-Within MATLAB (on Windows), type:
+- Windows:
+Within MATLAB, type:
   mex -I<icspath> -DWIN32 icsread.c <icspath>\libics.lib <zpath>\libz.lib
   mex -I<icspath> -DWIN32 icswrite.c <icspath>\libics.lib <zpath>\libz.lib
 from the directory containing both source files. If you compiled
@@ -66,5 +69,4 @@ the makefile.
 
 -------------------------------------------------------------
 Copyright (C) 2000-2010 Cris Luengo and others
-email: clluengo@users.sourceforge.net
 -------------------------------------------------------------

--- a/support/matlab/icsread.c
+++ b/support/matlab/icsread.c
@@ -6,16 +6,15 @@
  *        - Complex data is not read.
  *
  * Copyright (C) 2000-2007 Cris Luengo and others
- * email: clluengo@users.sourceforge.net
- * Last change: April 30, 2007
  */
 
-/* For MATLAB 7.3 and newer, remove the following line: */
-typedef int mwSize;
+/* For MATLAB 7.2 and older, uncomment the following line: */
+/* typedef int mwSize; */
 
 #include "mex.h"
 #include <string.h>
 #include "libics.h"
+#define ERROR_MESSAGE_LEN 2048
 
 void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    ICS* ip;
@@ -23,7 +22,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    mwSize mx_dims[ICS_MAXDIM];
    int ndims;
    size_t dims[ICS_MAXDIM];
-   size_t strides[ICS_MAXDIM];
+   ptrdiff_t strides[ICS_MAXDIM];
    size_t bufsize;
    void* buf;
    Ics_Error retval;
@@ -32,7 +31,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    int elemsize;
    int ii;
    size_t tmp;
-   char errormessage[2048];
+   char errormessage[ERROR_MESSAGE_LEN];
 
    if (strcmp (ICSLIB_VERSION, IcsGetLibVersion ()))
       mexErrMsgTxt ("Linking against the wrong version of the library.");
@@ -71,7 +70,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
          mexErrMsgTxt ("Couldn't open the file for reading.");
          break;
       default:
-         sprintf (errormessage, "Couldn't read the ICS header: %s", IcsGetErrorText (retval));
+         snprintf (errormessage, ERROR_MESSAGE_LEN, "Couldn't read the ICS header: %s", IcsGetErrorText (retval));
          mexErrMsgTxt (errormessage);
    }
    IcsGetLayout (ip, &dt, &ndims, dims);
@@ -133,12 +132,12 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    bufsize = mxGetNumberOfElements (plhs[0]) * elemsize;
    retval = IcsGetDataWithStrides (ip, buf, bufsize, strides, ndims);
    if (retval != IcsErr_Ok) {
-      sprintf (errormessage, "Couldn't read the image data: %s", IcsGetErrorText (retval));
+      snprintf (errormessage, ERROR_MESSAGE_LEN, "Couldn't read the image data: %s", IcsGetErrorText (retval));
       mexErrMsgTxt (errormessage);
    }
    retval = IcsClose (ip);
    if (retval != IcsErr_Ok) {
-      sprintf (errormessage, "Couldn't close the file pointer: %s", IcsGetErrorText (retval));
+      snprintf (errormessage, ERROR_MESSAGE_LEN, "Couldn't close the file pointer: %s", IcsGetErrorText (retval));
       mexErrMsgTxt (errormessage);
    }
 }

--- a/support/matlab/icswrite.c
+++ b/support/matlab/icswrite.c
@@ -7,16 +7,15 @@
  *        - Complex data is not written.
  *
  * Copyright (C) 2000-2007 Cris Luengo and others
- * email: clluengo@users.sourceforge.net
- * Last change: April 30, 2007
  */
 
-/* For MATLAB 7.3 and newer, remove the following line: */
-typedef int mwSize;
+/* For MATLAB 7.2 and older, uncomment the following line: */
+/* typedef int mwSize; */
 
 #include "mex.h"
 #include <string.h>
 #include "libics.h"
+#define ERROR_MESSAGE_LEN 2048
 
 void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    ICS* ip;
@@ -24,7 +23,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    int ndims;
    const mwSize* mx_dims;
    size_t dims[ICS_MAXDIM];
-   size_t strides[ICS_MAXDIM];
+   ptrdiff_t strides[ICS_MAXDIM];
    size_t bufsize;
    void* buf;
    Ics_Error retval;
@@ -33,7 +32,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    int elemsize, compress = 0;
    int ii;
    size_t tmp;
-   char errormessage[2048];
+   char errormessage[ERROR_MESSAGE_LEN];
 
    if (strcmp (ICSLIB_VERSION, IcsGetLibVersion ()))
       mexErrMsgTxt ("Linking against the wrong version of the library.");
@@ -124,7 +123,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    /* Now we know everything we need to write the data. */
    retval = IcsOpen (&ip, filename, "w1");
    if (retval != IcsErr_Ok) {
-      sprintf (errormessage, "Couldn't open the file for writing: %s", IcsGetErrorText (retval));
+      snprintf (errormessage, ERROR_MESSAGE_LEN, "Couldn't open the file for writing: %s", IcsGetErrorText (retval));
       mexErrMsgTxt (errormessage);
    }
    IcsSetLayout (ip, dt, ndims, dims);
@@ -133,7 +132,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
       mexWarnMsgTxt ("Couldn't create a SCIL_TYPE string.");
    retval = IcsSetDataWithStrides (ip, buf, bufsize, strides, ndims);
    if (retval != IcsErr_Ok) {
-      sprintf (errormessage, "Failed to set the data: %s", IcsGetErrorText (retval));
+      snprintf (errormessage, ERROR_MESSAGE_LEN, "Failed to set the data: %s", IcsGetErrorText (retval));
       mexErrMsgTxt (errormessage);
    }
    if (compress)
@@ -141,7 +140,7 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
    IcsAddHistory (ip, "software", "ICSWRITE under MATLAB with libics");
    retval = IcsClose (ip);
    if (retval != IcsErr_Ok) {
-      sprintf (errormessage, "Failed to create the ICS file: %s", IcsGetErrorText (retval));
+      snprintf (errormessage, ERROR_MESSAGE_LEN, "Failed to create the ICS file: %s", IcsGetErrorText (retval));
       mexErrMsgTxt (errormessage);
    }
 }

--- a/support/matlab/makefile
+++ b/support/matlab/makefile
@@ -1,6 +1,5 @@
 #
 # Copyright (C) 2000-2010 Cris Luengo and others
-# email: clluengo@users.sourceforge.net
 #
 # Makefile to compile matlab interface under Win32
 #


### PR DESCRIPTION
Clang deprecated `sprintf` recently (which is a little weird to do outside of the standard, but they're right in warning people about it).

Our use of `sprintf` is not dangerous, in none of the cases is there a possibility to cause an out-of-bounds write. But it's still better to use `snprintf` anyway, and the change is trivial.